### PR TITLE
incremental release action

### DIFF
--- a/incremental-release/README.md
+++ b/incremental-release/README.md
@@ -16,6 +16,7 @@ on:
       - master
 jobs:
   release:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
     timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:
@@ -33,7 +34,7 @@ jobs:
 ```
 
 Options:
-* `DEFAULT_INCREMENT` (default: `skip`): if no release keyword is found in the latest commit message, this value will be used to trigger a release
+* `DEFAULT_INCREMENT` (default: `skip`): If no release keyword is found in the latest commit message, this value will be used to trigger a release. Can be one of: `skip`, `patch`, `minor`, `major`.
 * `DRY_RUN` (default: `false`): Simulates a release but does not actually do one
 * `GITHUB_TOKEN`: Token to use to update version in 'package.json' and create the tag
 
@@ -47,6 +48,8 @@ Releases occur based on the most recent commit message:
 * Commits which contain `[increment patch]` will trigger a `patch` release. Example: `validate input before using [increment patch]`
 * Commits which contain `[increment minor]` will trigger a `minor` release. Example: `add toggle() method [increment minor]`
 * Commits which contain `[increment major]` will trigger a `major` release. Example: `breaking all the things [increment major]`
+
+**Note:** When merging a pull request, this will be the merge commit message.
 
 ### Default Increment
 

--- a/incremental-release/README.md
+++ b/incremental-release/README.md
@@ -1,0 +1,65 @@
+# Incremental Release Action
+
+This GitHub action looks for keywords in the latest commit to automatically increment the package version and create a tag.
+
+## Using the Action
+
+Typically this action is triggered from a workflow that runs on your `master` branch after each commit or pull request merge.
+
+Here's a sample release workflow:
+
+```yml
+name: Release
+on:
+  push:
+    branches:
+      - master
+jobs:
+  release:
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: Brightspace/third-party-actions@actions/checkout
+        with:
+          persist-credentials: false
+      - name: Setup Node
+        uses: Brightspace/third-party-actions@actions/setup-node
+        # additional validation steps can be run here
+      - name: Incremental Release
+        uses: BrightspaceUI/actions/incremental-release@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
+```
+
+Options:
+* `DEFAULT_INCREMENT` (default: `skip`): if no release keyword is found in the latest commit message, this value will be used to trigger a release
+* `DRY_RUN` (default: `false`): Simulates a release but does not actually do one
+* `GITHUB_TOKEN`: Token to use to update version in 'package.json' and create the tag
+
+Notes:
+* If you have additional release validation steps (e.g. build step, validation tests), run them after the "Setup Node" step and before the "Incremental Release" step.
+* In the checkout step, you must set the `persist-credentials` option to `false`. This opts out of the default `GITHUB_TOKEN` which is not an admin and cannot bypass branch protection rules.
+
+## Triggering a Release
+
+Releases occur based on the most recent commit message:
+* Commits which contain `[increment patch]` will trigger a `patch` release. Example: `validate input before using [increment patch]`
+* Commits which contain `[increment minor]` will trigger a `minor` release. Example: `add toggle() method [increment minor]`
+* Commits which contain `[increment major]` will trigger a `major` release. Example: `breaking all the things [increment major]`
+
+### Default Increment
+
+Normally, if the most recent commit does not contain `[increment major|minor|patch]`, no release will occur. However, by setting the `DEFAULT_INCREMENT` option you can control which type of release will occur.
+
+In this example, a minor release will occur if no increment value is found in the most recent commit:
+
+```yml
+uses: BrightspaceUI/actions/incremental-release@master
+with:
+  DEFAULT_INCREMENT: minor
+```
+
+### Skipping Releases
+
+When a default increment is specified, sometimes you want to bypass it and skip a release. To do this, include `[skip release]` in the commit message.

--- a/incremental-release/action.yml
+++ b/incremental-release/action.yml
@@ -1,0 +1,63 @@
+name: Incremental Release
+description: Create a release based on increment keywords in the most recent commit message
+inputs:
+  DEFAULT_INCREMENT:
+    description: Default increment if no value is found
+    default: skip
+  DRY_RUN:
+    description: Simulates a release but does not actually do one
+    default: false
+  GITHUB_TOKEN:
+    description: Token to use to update version in 'package.json' and create the tag
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Incremental Release
+      run: |
+        if [ ${{ contains(github.event.head_commit.message, 'skip ci') }} == true ]; then
+          echo "[skip ci] detected, so skipping release."
+          exit 0;
+        fi
+
+        TYPE=${DEFAULT_INCREMENT}
+        if [ ${{ contains(github.event.head_commit.message, '[increment patch]') }} == true ]; then
+          echo "Found [increment patch], creating a patch release..."
+          TYPE="patch"
+        elif [ ${{ contains(github.event.head_commit.message, '[increment minor]') }} == true ]; then
+          echo "Found [increment minor], creating a minor release..."
+          TYPE="minor"
+        elif [ ${{ contains(github.event.head_commit.message, '[increment major]') }} == true ]; then
+          echo "Found [increment major], creating a major release..."
+          TYPE="major"
+        elif [ ${{ contains(github.event.head_commit.message, '[skip version]') }} == true ]; then
+          echo "Found [skip version], skipping release..."
+          TYPE="skip"
+        else
+          echo "Did not find commit message flag, using DEFAULT_INCREMENT ($DEFAULT_INCREMENT)"
+        fi
+
+        if [ $TYPE == "skip" ]; then
+          echo "Skipping release."
+          exit 0;
+        fi
+
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        
+        echo "Executing: \"npm version ${TYPE}\"..."
+        NEW_VERSION=$(npm version ${TYPE} -m "Updated version to %s [skip ci][skip version]")
+        echo "New version number will be: $NEW_VERSION"
+
+        if [ ${{ inputs.DRY_RUN }} == true ]; then
+          echo "DRY_RUN option specified, aborting release creation."
+          exit 0;
+        fi
+        
+        echo "Executing: \"git push --follow-tags\""
+        git push --follow-tags
+
+      env:
+        DEFAULT_INCREMENT: ${{ inputs.DEFAULT_INCREMENT }}
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+      shell: bash

--- a/incremental-release/action.yml
+++ b/incremental-release/action.yml
@@ -20,7 +20,7 @@ runs:
           exit 0;
         fi
 
-        TYPE=${DEFAULT_INCREMENT}
+        TYPE=${{ inputs.DEFAULT_INCREMENT }}
         if [ ${{ contains(github.event.head_commit.message, '[increment patch]') }} == true ]; then
           echo "Found [increment patch], creating a patch release..."
           TYPE="patch"
@@ -34,7 +34,7 @@ runs:
           echo "Found [skip version], skipping release..."
           TYPE="skip"
         else
-          echo "Did not find commit message flag, using DEFAULT_INCREMENT ($DEFAULT_INCREMENT)"
+          echo "Did not find commit message flag, using DEFAULT_INCREMENT (${{ inputs.DEFAULT_INCREMENT }})"
         fi
 
         if [ $TYPE == "skip" ]; then
@@ -58,6 +58,5 @@ runs:
         git push --follow-tags
 
       env:
-        DEFAULT_INCREMENT: ${{ inputs.DEFAULT_INCREMENT }}
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       shell: bash

--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -22,6 +22,7 @@ on:
       - '[0-9]+.[0-9]+.x'
 jobs:
   release:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
     timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This action recreates the release portion of [frau-ci](https://github.com/Brightspace/frau-ci) with a GitHub action.

It can be used in places where using semantic-release may be overkill or not appropriate, such as in non-libraries which just want to release every time something merges.