### PR TITLE
include package-lock file if it's tracked

### DIFF
--- a/semantic-release/create-config.sh
+++ b/semantic-release/create-config.sh
@@ -1,3 +1,9 @@
+IS_TRACKED=$(git ls-files package-lock.json || true)
+if [ $IS_TRACKED != "" ]; then
+  ASSETS="[\"package.json\", \"package-lock.json\"]"
+else
+  ASSETS="[\"package.json\"]"
+fi
 cat >$FILE_PATH <<EOL
 {
   "plugins": [
@@ -13,9 +19,7 @@ cat >$FILE_PATH <<EOL
     [
       "@semantic-release/git",
       {
-        "assets": [
-          "package.json"
-        ],
+        "assets": $ASSETS,
         "message": "chore(release): \${nextRelease.version} [skip ci]"
       }
     ]


### PR DESCRIPTION
There were a few options to do this...

There's `npm config get package-lock` which will use the `.npmrc` value (or the system default), but if the system default is `false` that doesn't mean that someone isn't ignoring the lock file via `.gitignore`.

Which brings me to the other option -- look inside `.gitignore` and if you see `package-lock.json` in there, you know that it's _not_ using a lock file. But again, a lack of entry could just mean they've added it to their global ignore list, which is what I've done on my machine.

Which is why I just settled on asking `git` if the `package-lock.json` file is being tracked. If it is, then chances are they're using a lock file!
