### PR TITLE
Adding RELEASE and VERSION outputs

### DIFF
--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -47,6 +47,9 @@ Options:
 * `NPM` (default: `false`): Whether or not to release as an NPM package (see "NPM Package Deployment" below for more info)
 * `NPM_TOKEN` (optional if `NPM` is `false`): Token to publish to NPM (see "NPM Package Deployment" below for more info)
 
+Outputs:
+* `RELEASE`: `true` if a release occurred, `false` otherwise
+
 Notes:
 * If you have additional release validation steps (e.g. build step, validation tests), run them after the "Setup Node" step and before the "Semantic Release" step.
 * In the checkout step, you must set the `persist-credentials` option to `false`. This opts out of the default `GITHUB_TOKEN` which is not an admin and cannot bypass branch protection rules.

--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -49,6 +49,7 @@ Options:
 
 Outputs:
 * `RELEASE`: `true` if a release occurred, `false` otherwise
+* `VERSION`: will contain the new version number if a release occurred
 
 Notes:
 * If you have additional release validation steps (e.g. build step, validation tests), run them after the "Setup Node" step and before the "Semantic Release" step.

--- a/semantic-release/action.yml
+++ b/semantic-release/action.yml
@@ -16,6 +16,9 @@ outputs:
   RELEASE:
     description: Whether or not a release occurred
     value: ${{ steps.semantic-release.outputs.release }}
+  VERSION:
+    description: Version of the new release
+    value: ${{ steps.semantic-release.outputs.version }}
 runs:
   using: composite
   steps:
@@ -43,6 +46,7 @@ runs:
         NPM_TOKEN: ${{ inputs.NPM_TOKEN }}
       run: |
         echo "::set-output name=release::false"
+        echo "::set-output name=version::"
         if [ ${{ contains(github.event.head_commit.message, 'skip ci') }} == true ]; then
           echo "[skip ci] detected so skipping release"
           exit 0;
@@ -51,14 +55,15 @@ runs:
           echo "Running semantic-release (dry run)..."
           npx semantic-release --dry-run
         else
-          OLD_VERSION=$(grep version package.json)
+          OLD_VERSION=$(node -p -e "require('./package.json').version")
           echo "Running semantic-release..."
           npx semantic-release
-          NEW_VERSION=$(grep version package.json)
+          NEW_VERSION=$(node -p -e "require('./package.json').version")
           if [ "$OLD_VERSION" == "$NEW_VERSION" ]; then
             echo "::set-output name=release::false"
           else 
             echo "::set-output name=release::true"
+            echo "::set-output name=version::$(echo $NEW_VERSION)"
           fi
         fi
       shell: bash

--- a/semantic-release/action.yml
+++ b/semantic-release/action.yml
@@ -12,6 +12,10 @@ inputs:
     default: false
   NPM_TOKEN:
     description: Token to publish to NPM
+outputs:
+  RELEASE:
+    description: Whether or not a release occurred
+    value: ${{ steps.semantic-release.outputs.release }}
 runs:
   using: composite
   steps:
@@ -33,10 +37,12 @@ runs:
         NPM: ${{ inputs.NPM }}
       shell: bash
     - name: Running semantic-release
+      id: semantic-release
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ inputs.NPM_TOKEN }}
       run: |
+        echo "::set-output name=release::false"
         if [ ${{ contains(github.event.head_commit.message, 'skip ci') }} == true ]; then
           echo "[skip ci] detected so skipping release"
           exit 0;
@@ -45,7 +51,14 @@ runs:
           echo "Running semantic-release (dry run)..."
           npx semantic-release --dry-run
         else
+          OLD_VERSION=$(grep version package.json)
           echo "Running semantic-release..."
           npx semantic-release
+          NEW_VERSION=$(grep version package.json)
+          if [ "$OLD_VERSION" == "$NEW_VERSION" ]; then
+            echo "::set-output name=release::false"
+          else 
+            echo "::set-output name=release::true"
+          fi
         fi
       shell: bash

--- a/semantic-release/action.yml
+++ b/semantic-release/action.yml
@@ -59,9 +59,7 @@ runs:
           echo "Running semantic-release..."
           npx semantic-release
           NEW_VERSION=$(node -p -e "require('./package.json').version")
-          if [ "$OLD_VERSION" == "$NEW_VERSION" ]; then
-            echo "::set-output name=release::false"
-          else 
+          if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
             echo "::set-output name=release::true"
             echo "::set-output name=version::$(echo $NEW_VERSION)"
           fi


### PR DESCRIPTION
Was about to quickly convert `ifrau` and realized that it needs to know whether a release occurred or not and if it did what the new version is. This is needed by `frau-publisher` for CDN publishing, so most FRAs will need the same.

This outputs those two values.