### PR TITLE
removing release output

### DIFF
--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -48,8 +48,7 @@ Options:
 * `NPM_TOKEN` (optional if `NPM` is `false`): Token to publish to NPM (see "NPM Package Deployment" below for more info)
 
 Outputs:
-* `RELEASE`: `true` if a release occurred, `false` otherwise
-* `VERSION`: will contain the new version number if a release occurred
+* `VERSION`: will contain the new version number if a release occurred, empty otherwise
 
 Notes:
 * If you have additional release validation steps (e.g. build step, validation tests), run them after the "Setup Node" step and before the "Semantic Release" step.

--- a/semantic-release/action.yml
+++ b/semantic-release/action.yml
@@ -13,9 +13,6 @@ inputs:
   NPM_TOKEN:
     description: Token to publish to NPM
 outputs:
-  RELEASE:
-    description: Whether or not a release occurred
-    value: ${{ steps.semantic-release.outputs.release }}
   VERSION:
     description: Version of the new release
     value: ${{ steps.semantic-release.outputs.version }}
@@ -45,7 +42,6 @@ runs:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ inputs.NPM_TOKEN }}
       run: |
-        echo "::set-output name=release::false"
         echo "::set-output name=version::"
         if [ ${{ contains(github.event.head_commit.message, 'skip ci') }} == true ]; then
           echo "[skip ci] detected so skipping release"
@@ -60,7 +56,6 @@ runs:
           npx semantic-release
           NEW_VERSION=$(node -p -e "require('./package.json').version")
           if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
-            echo "::set-output name=release::true"
             echo "::set-output name=version::$(echo $NEW_VERSION)"
           fi
         fi


### PR DESCRIPTION
This ended up being a string `'true'` or `'false'` which made it kind of redundant with the `VERSION` since you could just compare that to empty, so removing it to simplify.