### PR TITLE
excluding node_modules from default mocha test path

### DIFF
--- a/visual-diff/README.md
+++ b/visual-diff/README.md
@@ -42,9 +42,8 @@ Options:
 * `AWS_SECRET_ACCESS_KEY`: Access key secret for the role that will assume the visual diff role - see [setup details](#setting-up-aws-access-creds) below.
 * `AWS_SESSION_TOKEN`: Session token for the role that will assume the visual diff role - see [setup details](#setting-up-aws-access-creds) below.
 * `GITHUB_TOKEN`: Token to use to open the goldens PR.  This does not need admin privileges, so you can use the standard `GITHUB_TOKEN` that exists automatically.
-* `TEST_PATH` (default: `./**/*.visual-diff.js`): Path passed into the mocha call defining the locations and name structure of the tests.
+* `TEST_PATH` (default: `./{,!(node_modules)/**}/*.visual-diff.js`): Path passed into the mocha call defining the locations and name structure of the tests.
 * `TEST_TIMEOUT` (default: `40000`): Test timeout passed into the mocha call.
-
 
 Notes:
 * You can also run this action in your release workflow to confirm the `master` branch is in a good state before releasing.  If there's a problem, a PR will be opened against `master` to get the goldens back in the expected state.  This mostly comes down to a time versus risk trade-off - the risk of things getting out of sync may be lower than the time taken to run your visual diff tests every release.

--- a/visual-diff/action.yml
+++ b/visual-diff/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: true
   TEST_PATH:
     description: Path passed into the mocha call defining the locations and name structure of the tests
-    default: './**/*.visual-diff.js'
+    default: './{,!(node_modules)/**}/*.visual-diff.js'
   TEST_TIMEOUT:
     description: Test timeout passed into the mocha call
     default: 40000


### PR DESCRIPTION
Repos like `consistent-evaluation` that include other D2L projects with visual-diff tests using a GitHub reference run into a scenario where the default test path (`./**/*.visual-diff.js`) finds the visual diff tests in those dependency repos.

So we either change the default to just look in `./test/**/*.visual-diff.js` where we'd need to fix a few repos like `core`, or we apply this fix which will _exclude_ `node_modules`.