### PR TITLE
the release name needs to contain "v"

### DIFF
--- a/incremental-release/create-release.js
+++ b/incremental-release/create-release.js
@@ -1,6 +1,6 @@
 const { Octokit } = require('@octokit/rest');
 
-const release = process.argv[2];
+const release = `v${process.argv[2]}`;
 const [owner, repo] = process.env['GITHUB_REPOSITORY'].split('/');
 
 const octokit = new Octokit({


### PR DESCRIPTION
This fixes a bug introduced yesterday that @jeroach noticed. The release name needs to continue to start with "v", otherwise it doesn't get linked up with the corresponding tag name (that contained "v") and it decides to create another tag -- resulting in tags "1.2.3" _and_ "v1.2.3".