### PR TITLE
Add warning when the stash apply fails because of merge conflicts from outdated goldens

### DIFF
--- a/visual-diff/action.yml
+++ b/visual-diff/action.yml
@@ -82,7 +82,11 @@ runs:
         git fetch origin +refs/heads/$SOURCE_BRANCH:refs/heads/$SOURCE_BRANCH -q || true
         git checkout $SOURCE_BRANCH
         git checkout -b $VISUAL_DIFF_BRANCH
-        git stash apply
+        if ! git stash apply; then
+          echo -e "\e[31mCould not apply stash - merge conflicts with ${{ github.event.pull_request.base.ref }}."
+          echo "::set-output name=goldens-conflict::$(echo true)"
+          exit 0;
+        fi
         
         echo -e "\n\e[34mCommitting new goldens"
         git config user.name github-actions
@@ -98,17 +102,23 @@ runs:
       shell: bash
     - name: Handling the Goldens PR (if necessary)
       run: |   
-        if [ ${{ steps.visual-diff-tests.outputs.tests-passed }} == true ]; then
+        if [ ${{ steps.visual-diff-tests.outputs.tests-passed }} == true ] || [ ${{ steps.committing-goldens.outputs.goldens-conflict }} == true ]; then
           if git ls-remote --exit-code --heads origin $VISUAL_DIFF_BRANCH; then
             echo -e "\e[34mClosing Goldens PR and Deleting Branch"
             git push -d origin $VISUAL_DIFF_BRANCH || true
           fi
+        fi
      
+        if [ ${{ steps.visual-diff-tests.outputs.tests-passed }} == true ]; then
           echo -e "\e[32mCompleted - Build Passed."
           exit 0;
         fi
-
-        node ${{ github.action_path }}/handle-pr.js
+        
+        if [ ${{ steps.committing-goldens.outputs.goldens-conflict }} == true ]; then
+          node ${{ github.action_path }}/handle-goldens-conflict.js
+        else 
+          node ${{ github.action_path }}/handle-pr.js
+        fi
  
         echo -e "\e[31mCompleted - Build Failed."
         exit 1;
@@ -117,6 +127,7 @@ runs:
         FORCE_COLOR: 3
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         PULL_REQUEST_NUM: ${{ github.event.number }}
+        PULL_REQUEST_BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         SOURCE_BRANCH: ${{ steps.committing-goldens.outputs.source-branch }}
         VISUAL_DIFF_BRANCH: ${{ steps.committing-goldens.outputs.visual-diff-branch }}
       shell: bash

--- a/visual-diff/handle-goldens-conflict.js
+++ b/visual-diff/handle-goldens-conflict.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+const chalk = require('chalk');
+const { Octokit } = require('@octokit/rest');
+
+const octokit = new Octokit({
+	auth: process.env['GITHUB_TOKEN'],
+	baseUrl: process.env['GITHUB_API_URL'],
+	userAgent: `${process.env['GITHUB_WORKFLOW']}-visual-diff`
+});
+
+const [owner, repo] = process.env['GITHUB_REPOSITORY'].split('/');
+const prBaseBranchName = process.env['PULL_REQUEST_BASE_BRANCH'];
+const prNum = process.env['PULL_REQUEST_NUM'];
+
+async function handleGoldensConflict() {
+	console.log('Adding comment to pull request about goldens conflict.\n');
+
+	await octokit.request('POST /repos/{owner}/{repo}/issues/{issue_number}/comments', {
+		owner: owner,
+		repo: repo,
+		issue_number: prNum,
+		body: `Could not generate new goldens - your code changes will update golden files that you do not have the latest version of.  Please rebase or merge \`${prBaseBranchName}\` into your branch.`
+	});
+}
+
+handleGoldensConflict().catch((e) => {
+	console.log(chalk.red(e));
+	console.log(chalk.red('Could not handle goldens conflict.'));
+});


### PR DESCRIPTION
I tried numerous ways to avoid this scenario - by applying the goldens using stashes, by resetting, by trying to fix the merge conflicts automatically, etc.  In the end, GitHub and git really don't handle binary file conflicts well and would still complain about a conflict that needs to be resolved manually.

This tries to warn of the conflict early - if your branch is missing changes to golden files that you will be changing, the visual-diff tests fail and a comment is made on your PR telling you to rebase or merge in master (or whatever branch is the PR base).  However, if someone merges their golden changes _after_ you've already updated the goldens in your branch, you'll get the conflict.  This would have happened regardless.