### PR TITLE
Add visual-diff branch cleanup

### DIFF
--- a/visual-diff/cleanup-branches.js
+++ b/visual-diff/cleanup-branches.js
@@ -3,17 +3,60 @@
 const chalk = require('chalk');
 const { Octokit } = require('@octokit/rest');
 
-const [owner, repo] = process.env['GITHUB_REPOSITORY'].split('/');
-const branchPrefix = process.env['VISUAL_DIFF_BRANCH_PREFIX'];
-
 const octokit = new Octokit({
 	auth: process.env['GITHUB_TOKEN'],
 	baseUrl: process.env['GITHUB_API_URL'],
 	userAgent: `${process.env['GITHUB_WORKFLOW']}-visual-diff`
 });
 
+const [owner, repo] = process.env['GITHUB_REPOSITORY'].split('/');
+const branchPrefix = process.env['VISUAL_DIFF_BRANCH_PREFIX'];
+
 async function cleanupBranches() {
-	console.log(`Coming soon... will cleanup ${branchPrefix}* branches.\n`);
+	const visualDiffBranches = await octokit.request('GET /repos/{owner}/{repo}/git/matching-refs/{ref}', {
+		owner: owner,
+		repo: repo,
+		ref: `heads/${branchPrefix}`
+	});
+
+	for (let i = 0; i < visualDiffBranches.data.length; i++) {
+		const branch = visualDiffBranches.data[i].ref;
+		const prNum = branch.slice(branch.lastIndexOf('-') + 1);
+
+		let prInfo,
+			prOpen = true;
+		try {
+			prInfo = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+				owner: owner,
+				repo: repo,
+				pull_number: prNum
+			});
+
+			if (prInfo.data.state !== 'open') {
+				prOpen = false;
+			}
+		} catch (e) {
+			console.log(chalk.red(e));
+			console.log(chalk.red(`Could not get details for PR #${prNum} - skipping branch ${branch}.`));
+			continue;
+		}
+
+		if (!prOpen) {
+			console.log(`PR #${prNum} is no longer open - deleting branch ${branch}.\n`);
+			try {
+				await octokit.request('DELETE /repos/{owner}/{repo}/git/refs/{ref}', {
+					owner: owner,
+					repo: repo,
+					ref: branch.substring(5)
+				});
+			} catch (e) {
+				console.log(chalk.red(e));
+				console.log(chalk.red(`Could not delete branch ${branch}.`));
+			}
+		}
+	}
+
+	console.log('Done processing visual-diff branches.\n');
 }
 
 cleanupBranches().catch((e) => {


### PR DESCRIPTION
This was a feature we talked about that was a nice-to-have, so was deferred until after we'd gotten Travis replaced everywhere.

At the beginning of the action, we pull all the visual diff PR branches and make sure the PR they correspond to is still open.  If not, the branch is deleted.  This helps cleanup branches if a PR was closed but the corresponding visual-diff one was not - if the PR was later reopened, visual-diff would have rerun anyways.

It would make more sense to run this on every PR close but that would require it's own workflow, or on a schedule but that feels like overkill.  Running it every time we run visual-diff tests is a compromise.