### PR TITLE
Handle PR reviewer error more gracefully

### DIFF
--- a/visual-diff/handle-pr.js
+++ b/visual-diff/handle-pr.js
@@ -120,14 +120,19 @@ async function handlePR() {
 	}
 
 	console.log('Adding PR Reviewers');
-	await octokit.request('POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers', {
-		owner: owner,
-		repo: repo,
-		pull_number: goldenPrNum,
-		reviewers: [
-			actor
-		]
-	});
+	try {
+		await octokit.request('POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers', {
+			owner: owner,
+			repo: repo,
+			pull_number: goldenPrNum,
+			reviewers: [
+				actor
+			]
+		});
+	} catch (e) {
+		console.log('Could not add reviewer (expected for Dependabot PRs):');
+		console.log(e);
+	}
 }
 
 handlePR().catch((e) => {


### PR DESCRIPTION
I didn't anticipate this originally, but it might be common for Dependabot to cause visual-diff changes by pulling in new versions of core and such.  We also saw this in core with a flakey visual diff test.  I can't add Dependabot as a reviewer, and I don't want to fail the script on not being able to add a reviewer anyways.  It doesn't really matter because it's the last step in the script, but it might not always be.