### PR TITLE
including more info about D2L_GITHUB_TOKEN

### DIFF
--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,41 @@
+# Branch Protection and Release Workflows
+
+Included in both the [semantic-release](../semantic-release/) and [incremental-release](../incremental-release) workflows is a step which updates the version in your repo's `package.json` file to match the newly released version. This step will fail with the built-in `GITHUB_TOKEN` if your repo has branch protection rules that prevent commits outside of pull requests.
+
+To work around this, we use a special `D2L_GITHUB_TOKEN`.
+
+To set up this bypass:
+
+1) Ensure that `D2L_GITHUB_TOKEN` is a secret available to your repo
+
+For repos in `BrightspaceUI`, `BrightspaceUILabs` and `BrightspaceHypermediaComponents` this secret will already be available org-wide. Repos in the `Brightspace` organization will need to have it set manually in each individual repository.
+
+We plan to automate the configuration and rotation of this secret in the future, but for now reach out to Dave Lockhart to get this secret added to your repo.
+
+2) Configure access to the `brightspace-bot`
+
+This is also a temporary step, but make sure that the `brightspace-bot` GitHub account has Admin access to your repo.
+
+Also double-check that your branch protection doesn't include a rule to "Include Administrators".
+
+3) Set `persists-credentials` to `false` in the checkout step:
+
+```yml
+name: Checkout
+  uses: Brightspace/third-party-actions@actions/checkout
+  with:
+    persist-credentials: false
+```
+
+This tells GitHub Actions not to set up the default `GITHUB_TOKEN`.
+
+4) Pass in `D2L_GITHUB_TOKEN` as the `GITHUB_TOKEN` environment variable to the release step:
+
+```yml
+- name: Semantic/Incremental Release
+  uses: BrightspaceUI/actions/semantic-release@master (or incremental-release)
+  with:
+    GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
+```
+
+That should do it!

--- a/incremental-release/README.md
+++ b/incremental-release/README.md
@@ -26,7 +26,6 @@ jobs:
           persist-credentials: false
       - name: Setup Node
         uses: Brightspace/third-party-actions@actions/setup-node
-        # additional validation steps can be run here
       - name: Incremental Release
         uses: BrightspaceUI/actions/incremental-release@master
         with:
@@ -36,14 +35,19 @@ jobs:
 Options:
 * `DEFAULT_INCREMENT` (default: `skip`): If no release keyword is found in the latest commit message, this value will be used to trigger a release. Can be one of: `skip`, `patch`, `minor`, `major`.
 * `DRY_RUN` (default: `false`): Simulates a release but does not actually do one
-* `GITHUB_TOKEN`: Token to use to update version in 'package.json' and create the tag
+* `GITHUB_TOKEN`: Token to use to update version in 'package.json' and create the tag -- see section below on branch protection for more details
 
 Outputs:
 * `VERSION`: will contain the new version number if a release occurred, empty otherwise
 
 Notes:
 * If you have additional release validation steps (e.g. build step, validation tests), run them after the "Setup Node" step and before the "Incremental Release" step.
-* In the checkout step, you must set the `persist-credentials` option to `false`. This opts out of the default `GITHUB_TOKEN` which is not an admin and cannot bypass branch protection rules.
+
+### Branch Protection Rules and D2L_GITHUB_TOKEN
+
+The release step will fail to write to `package.json` if you have branch protection rules set up in your repository. To get around this, we use a special Admin `D2L_GITHUB_TOKEN`.
+
+[../docs/branch-protection.md](Learn how to set up the D2L_GITHUB_TOKEN...)
 
 ## Triggering a Release
 

--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -32,7 +32,6 @@ jobs:
           persist-credentials: false
       - name: Setup Node
         uses: Brightspace/third-party-actions@actions/setup-node
-        # additional validation steps can be run here
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@master
         with:
@@ -43,7 +42,7 @@ jobs:
 
 Options:
 * `DRY_RUN` (default: `false`): Runs semantic-release with the `--dry-run` flag to simulate a release but not actually do one
-* `GITHUB_TOKEN`: Token to use to update version in 'package.json' and create GitHub release
+* `GITHUB_TOKEN`: Token to use to update version in 'package.json' and create GitHub release -- see section below on branch protection for more details
 * `NPM` (default: `false`): Whether or not to release as an NPM package (see "NPM Package Deployment" below for more info)
 * `NPM_TOKEN` (optional if `NPM` is `false`): Token to publish to NPM (see "NPM Package Deployment" below for more info)
 
@@ -52,8 +51,13 @@ Outputs:
 
 Notes:
 * If you have additional release validation steps (e.g. build step, validation tests), run them after the "Setup Node" step and before the "Semantic Release" step.
-* In the checkout step, you must set the `persist-credentials` option to `false`. This opts out of the default `GITHUB_TOKEN` which is not an admin and cannot bypass branch protection rules.
 * This example will release only from `master` and maintenance branches (e.g. `1.15.x` or `2.x`) -- see more info about maintenance branches below.
+
+### Branch Protection Rules and D2L_GITHUB_TOKEN
+
+The release step will fail to write to `package.json` if you have branch protection rules set up in your repository. To get around this, we use a special Admin `D2L_GITHUB_TOKEN`.
+
+[../docs/branch-protection.md](Learn how to set up the D2L_GITHUB_TOKEN...)
 
 ## NPM Package Deployment
 


### PR DESCRIPTION
For repos in the Brightspace org, properly setting up the special token continues to be tricky since the docs don't really call out what's required.

I was avoiding writing this initially since the process will change, but for now it's needed.