### PR TITLE
add support for releasing from "main" branch

### DIFF
--- a/semantic-release/create-config.sh
+++ b/semantic-release/create-config.sh
@@ -6,6 +6,17 @@ else
 fi
 cat >$FILE_PATH <<EOL
 {
+  "release": {
+    "branches": [
+      "+([0-9])?(.{+([0-9]),x}).x",
+      "main",
+      "master",
+      "next",
+      "next-major",
+      {name: "beta", prerelease: true},
+      {name: "alpha", prerelease: true}
+    ]
+  },
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/github",


### PR DESCRIPTION
GitHub has rightly moved to `main` as the default branch (instead of `master`), and we should be supporting that as well.

semantic-release has an [outstanding issue](https://github.com/semantic-release/semantic-release/issues/1581) to add `main` to their default config or have some way to specify what default branch you'd like, but it hasn't received much traction.

The workaround is to simply copy the default branches config (which I've done here) and add `main`. When & if semantic-release addresses this in the default config (or through other means) we can revert this back.