### PR TITLE
making default branch an option

### DIFF
--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -41,6 +41,8 @@ jobs:
 ```
 
 Options:
+
+* `DEFAULT_BRANCH` (default: `"master"`): name of the default release branch
 * `DRY_RUN` (default: `false`): Runs semantic-release with the `--dry-run` flag to simulate a release but not actually do one
 * `GITHUB_TOKEN`: Token to use to update version in 'package.json' and create GitHub release -- see section below on branch protection for more details
 * `NPM` (default: `false`): Whether or not to release as an NPM package (see "NPM Package Deployment" below for more info)

--- a/semantic-release/action.yml
+++ b/semantic-release/action.yml
@@ -1,6 +1,9 @@
 name: Semantic Release
 description: Deploy using semantic-release
 inputs:
+  DEFAULT_BRANCH:
+    description: name of the default release branch
+    default: master
   DRY_RUN:
     description: Runs semantic-release with the "--dry-run" flag to simulate a release but not actually do one
     default: false
@@ -29,10 +32,11 @@ runs:
     - name: Create semantic-release configuration
       run: |
         if [ ${{ !contains(github.event.head_commit.message, 'skip ci') }} == true ]; then
-          echo "Creating semantic-relase configuration (NPM: ${{ inputs.NPM }})..."
+          echo "Creating semantic-release configuration (DEFAULT_BRANCH: ${{ inputs.DEFAULT_BRANCH }} , NPM: ${{ inputs.NPM }})..."
           ${{ github.action_path }}/create-config.sh
         fi
       env:
+        DEFAULT_BRANCH: ${{ inputs.DEFAULT_BRANCH }}
         FILE_PATH: ${{ github.workspace }}/.releaserc.yml
         NPM: ${{ inputs.NPM }}
       shell: bash

--- a/semantic-release/create-config.sh
+++ b/semantic-release/create-config.sh
@@ -9,8 +9,7 @@ cat >$FILE_PATH <<EOL
   "release": {
     "branches": [
       "+([0-9])?(.{+([0-9]),x}).x",
-      "main",
-      "master",
+      "$DEFAULT_BRANCH",
       "next",
       "next-major",
       {name: "beta", prerelease: true},


### PR DESCRIPTION
@surags got a chance to use this and it didn't end up working. Apparently you can't have multiple default release branches in your config like this.

So turning this into an option that repos can opt into. 