### PR TITLE
fix(semantic-release): resolve variable value.

### DIFF
--- a/semantic-release/create-config.sh
+++ b/semantic-release/create-config.sh
@@ -1,5 +1,5 @@
 IS_TRACKED=$(git ls-files package-lock.json || true)
-if [ $IS_TRACKED != "" ]; then
+if [ "$IS_TRACKED" != "" ]; then
   ASSETS="[\"package.json\", \"package-lock.json\"]"
 else
   ASSETS="[\"package.json\"]"


### PR DESCRIPTION
I noticed a `/home/runner/work/_actions/BrightspaceUI/actions/master/semantic-release/create-config.sh: line 2: [: !=: unary operator expected
` error on https://github.com/Brightspace/frau-locale-provider/runs/2353432455#step:4:19. I think this resolves it.

(Sorry not sure how to test this change).