### PR TITLE
Switch the goldens PR to open as a draft PR

### DIFF
--- a/visual-diff/README.md
+++ b/visual-diff/README.md
@@ -1,9 +1,9 @@
 # Visual Diff Action
 
-This GitHub action runs your repo's [visual diff tests](https://github.com/BrightspaceUI/visual-diff).  If the tests fail, a PR will be opened with the new goldens against the branch/PR that triggered the action.  If they pass, any open goldens PRs for that branch/PR will be closed for you.
+This GitHub action runs your repo's [visual diff tests](https://github.com/BrightspaceUI/visual-diff).  If the tests fail, a draft PR will be opened with the new goldens against the branch/PR that triggered the action.  If they pass, any open goldens PRs for that branch/PR will be closed for you.
 
 More specifically, this action will:
-* Install the `@brightspace-ui/visual-diff`, `mocha` and `puppeteer` dependencies for you, so you don't need to include them in your local `devDependencies`
+* Install the `@brightspace-ui/visual-diff`, `esm`, `mocha` and `puppeteer` dependencies for you, so you don't need to include them in your local `devDependencies`
 * Cleanup abandoned golden PRs
 * Run your visual diff tests and display the results (including links to the visual diff reports stored in S3)
 * If failures occurred, it will open/update the corresponding goldens PR with the new goldens and links to the failed reports

--- a/visual-diff/handle-pr.js
+++ b/visual-diff/handle-pr.js
@@ -87,6 +87,7 @@ async function handlePR() {
 			title: prNum ? `Updating Visual Diff Goldens for PR ${prNum}` : `Updating Visual Diff Goldens for Branch ${sourceBranchName}`,
 			head: `refs/heads/${goldensBranchName}`,
 			base: `refs/heads/${sourceBranchName}`,
+			draft: true,
 			body: createPRBody()
 		});
 		goldenPrNum = newPR.data.number;


### PR DESCRIPTION
Opening the goldens PR as a draft PR means teams won't get notified about it in slack (if drafts are ignored) or as codeowners until it's actually ready to be merged, meaning less noise about flakes and bugs found and fixed.  It will mean that you'll now need to press "Ready for review" before merging the PR.

This will only open the PR as a draft.  If you change it to a "Ready to review" PR and then more golden changes are added, it won't turn it back into a draft PR.