### PR TITLE
Make opening the goldens PR as a draft PR a configurable option

### DIFF
--- a/visual-diff/README.md
+++ b/visual-diff/README.md
@@ -41,6 +41,7 @@ Options:
 * `AWS_ACCESS_KEY_ID`: Access key id for the role that will assume the visual diff role - see [setup details](#setting-up-aws-access-creds) below.
 * `AWS_SECRET_ACCESS_KEY`: Access key secret for the role that will assume the visual diff role - see [setup details](#setting-up-aws-access-creds) below.
 * `AWS_SESSION_TOKEN`: Session token for the role that will assume the visual diff role - see [setup details](#setting-up-aws-access-creds) below.
+* `DRAFT_PR` (default: `true`): Whether to open the goldens PR as a draft PR.
 * `GITHUB_TOKEN`: Token to use to open the goldens PR.  This does not need admin privileges, so you can use the standard `GITHUB_TOKEN` that exists automatically.
 * `TEST_PATH` (default: `./{,!(node_modules)/**}/*.visual-diff.js`): Path passed into the mocha call defining the locations and name structure of the tests.
 * `TEST_TIMEOUT` (default: `40000`): Test timeout passed into the mocha call.

--- a/visual-diff/action.yml
+++ b/visual-diff/action.yml
@@ -10,6 +10,9 @@ inputs:
   AWS_SESSION_TOKEN:
     description: Session token for the role that will assume the visual diff role
     required: true
+  DRAFT_PR:
+    description: Whether to open the goldens PR as a draft PR
+    default: true
   GITHUB_TOKEN:
     description: Token to use to open the goldens PR
     required: true
@@ -139,6 +142,7 @@ runs:
         echo -e "\e[31mCompleted - Build Failed."
         exit 1;
       env:
+        DRAFT_PR: ${{ inputs.DRAFT_PR }}
         FAILED_REPORTS: ${{ steps.visual-diff-tests.outputs.failed-reports }}
         FORCE_COLOR: 3
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}

--- a/visual-diff/handle-pr.js
+++ b/visual-diff/handle-pr.js
@@ -87,7 +87,7 @@ async function handlePR() {
 			title: prNum ? `Updating Visual Diff Goldens for PR ${prNum}` : `Updating Visual Diff Goldens for Branch ${sourceBranchName}`,
 			head: `refs/heads/${goldensBranchName}`,
 			base: `refs/heads/${sourceBranchName}`,
-			draft: true,
+			draft: process.env['DRAFT_PR'].toLowerCase() === 'false' ? false : true,
 			body: createPRBody()
 		});
 		goldenPrNum = newPR.data.number;


### PR DESCRIPTION
Opening as a draft PR cuts down on the noise to CODEOWNERS in situations where a test flakes or golden changes shouldn't occur and a PR fix is needed.  But in more "monorepo-like" situations where goldens can fail by a different team putting up a seemingly unrelated PR, it's preferred to have CODEOWNERS notified immediately so they can look into things.  So below I'm adding an input to turn off the draft PR feature in the action.