### PR TITLE
Update README with GITHUB_TOKEN restrictions

### DIFF
--- a/update-package-lock/README.md
+++ b/update-package-lock/README.md
@@ -40,7 +40,7 @@ Options:
 
 ## Setting GITHUB_TOKEN
 
-The `GITHUB_TOKEN` is used to open the PR with the `package-lock.json` updates. This token does not need admin privileges, so the standard `secrets.GITHUB_TOKEN` _can_ work.  However, this token [does not trigger additional workflows](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow).  If you use GitHub actions for your CI, you probably want to use `D2L_GITUB_TOKEN` here instead.
+The `GITHUB_TOKEN` is used to open the PR with the `package-lock.json` updates. This token does not need admin privileges, so the standard `secrets.GITHUB_TOKEN` _can_ work.  However, that token [does not trigger additional workflows](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow).  If you use GitHub actions for your CI, you probably want to use `D2L_GITHUB_TOKEN` here instead.
 
 [Learn more about the D2L_GITHUB_TOKEN...](../docs/branch-protection.md)
 

--- a/update-package-lock/README.md
+++ b/update-package-lock/README.md
@@ -35,10 +35,10 @@ Options:
 * `BRANCH_NAME` (default: `ghworkflow/package_lock_auto_update`): Name of the branch to add the changes to and open the pull request from.
 * `COMMIT_MESSAGE` (default: `Auto Update Dependencies`): Commit message for the changes.
 * `DEFAULT_BRANCH` (default: `main`): Name of the default release branch for your repo.
-* `GITHUB_TOKEN` (required): Token for opening the updates PR. See [setup details](#setting-a-github-token) below.
+* `GITHUB_TOKEN` (required): Token for opening the updates PR. See [setup details](#setting-github-token) below.
 * `PR_TITLE` (default: `Updating package-lock.json`): Title for the opened pull request.
 
-## Setting a GITHUB_TOKEN
+## Setting GITHUB_TOKEN
 
 The `GITHUB_TOKEN` is used to open the PR with the `package-lock.json` updates. This token does not need admin privileges, so the standard `secrets.GITHUB_TOKEN` _can_ work.  However, this token [does not trigger additional workflows](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow).  If you use GitHub actions for your CI, you probably want to use `D2L_GITUB_TOKEN` here instead.
 
@@ -57,4 +57,4 @@ Setting the PR to auto-merge is another optional enhancement of this action. Req
 * Branch protection needs to be on for the default release branch, and enforces "Require pull request reviews before merging" or "Require status checks to pass before merging" or something similar. This is because auto-merge only works for cases where PRs cannot be merged immediately after opening.
 * While not required, it's highly recommended to [enable "Automatically delete head branches"](https://docs.github.com/en/github/administering-a-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches) before using auto-merge, to help cleanup branches after they are automatically merged.
 
-Like with [setting the `GITHUB_TOKEN` above](#setting-a-github-token), setting `AUTO_MERGE_TOKEN` to `secrets.GITHUB_TOKEN` will work, but will not trigger any "push" workflows you've setup to run after a merge to your default branch.  If you _do_ need those triggered, you'll want to use `D2L_GITHUB_TOKEN`.
+Like with [setting the `GITHUB_TOKEN` above](#setting-github-token), setting `AUTO_MERGE_TOKEN` to `secrets.GITHUB_TOKEN` will work, but will not trigger any "push" workflows you've setup to run after a merge to your default branch.  If you _do_ need those triggered, you'll want to use `D2L_GITHUB_TOKEN`.

--- a/update-package-lock/README.md
+++ b/update-package-lock/README.md
@@ -26,7 +26,7 @@ jobs:
         uses: BrightspaceUI/actions/update-package-lock@master
         with:
           DEFAULT_BRANCH: master
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
 ```
 
 Options:
@@ -35,14 +35,18 @@ Options:
 * `BRANCH_NAME` (default: `ghworkflow/package_lock_auto_update`): Name of the branch to add the changes to and open the pull request from.
 * `COMMIT_MESSAGE` (default: `Auto Update Dependencies`): Commit message for the changes.
 * `DEFAULT_BRANCH` (default: `main`): Name of the default release branch for your repo.
-* `GITHUB_TOKEN`: Token for opening the updates PR. This does not need admin privileges, so you can use the standard `GITHUB_TOKEN` that exists automatically.
+* `GITHUB_TOKEN` (required): Token for opening the updates PR. See [setup details](#setting-a-github-token) below.
 * `PR_TITLE` (default: `Updating package-lock.json`): Title for the opened pull request.
+
+## Setting a GITHUB_TOKEN
+
+The `GITHUB_TOKEN` is used to open the PR with the `package-lock.json` updates. This token does not need admin privileges, so the standard `secrets.GITHUB_TOKEN` _can_ work.  However, this token [does not trigger additional workflows](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow).  If you use GitHub actions for your CI, you probably want to use `D2L_GITUB_TOKEN` here instead.
+
+[Learn more about the D2L_GITHUB_TOKEN...](../docs/branch-protection.md)
 
 ## Setting Up Auto Approval
 
-Automatically approving the PR is an optional enhancement this action can handle for you by setting an `APPROVAL_TOKEN`. The `APPROVAL_TOKEN` needs to be _different_ than the `GITHUB_TOKEN` because a token cannot approve its own PR. The token only needs to have write permissions, but `D2L_GITHUB_TOKEN` will work.
-
-[Learn more about the D2L_GITHUB_TOKEN...](../docs/branch-protection.md)
+Automatically approving the PR is an optional enhancement this action can handle for you by setting an `APPROVAL_TOKEN`. The `APPROVAL_TOKEN` needs to be _different_ than the `GITHUB_TOKEN` because a token cannot approve its own PR. If you used `D2L_GITHUB_TOKEN` to open the PR, you can use `GITHUB_TOKEN` to approve it, and vice versa.
 
 Note: This functionality may not be helpful to you if you require CODEOWNERS approval to merge.  You could consider removing CODEOWNERS for the `package-lock.json` file specifically.
 
@@ -53,4 +57,4 @@ Setting the PR to auto-merge is another optional enhancement of this action. Req
 * Branch protection needs to be on for the default release branch, and enforces "Require pull request reviews before merging" or "Require status checks to pass before merging" or something similar. This is because auto-merge only works for cases where PRs cannot be merged immediately after opening.
 * While not required, it's highly recommended to [enable "Automatically delete head branches"](https://docs.github.com/en/github/administering-a-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches) before using auto-merge, to help cleanup branches after they are automatically merged.
 
-Note: Setting `AUTO_MERGE_TOKEN` to the `GITHUB_TOKEN` will work, but will not trigger any "push" workflows you've setup to run after a merge to your default branch.  If you _do_ need those triggered, you'll want to use the same token as `APPROVAL_TOKEN` (for example, `D2L_GITHUB_TOKEN`).
+Like with [setting the `GITHUB_TOKEN` above](#setting-a-github-token), setting `AUTO_MERGE_TOKEN` to `secrets.GITHUB_TOKEN` will work, but will not trigger any "push" workflows you've setup to run after a merge to your default branch.  If you _do_ need those triggered, you'll want to use `D2L_GITHUB_TOKEN`.


### PR DESCRIPTION
Found this restriction when setting up the `update-package-lock` action in the `documentation` repo.  BSI didn't have this problem because its CI is still using Travis.  It'll need to switch the tokens its using once it moves CI to GitHub actions.