### PR TITLE
preparations to rename master branch to main

### DIFF
--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -33,7 +33,7 @@ This tells GitHub Actions not to set up the default `GITHUB_TOKEN`.
 
 ```yml
 - name: Semantic/Incremental Release
-  uses: BrightspaceUI/actions/semantic-release@master (or incremental-release)
+  uses: BrightspaceUI/actions/semantic-release@main (or incremental-release)
   with:
     GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
 ```

--- a/incremental-release/README.md
+++ b/incremental-release/README.md
@@ -4,7 +4,7 @@ This GitHub action looks for keywords in the latest commit to automatically incr
 
 ## Using the Action
 
-Typically this action is triggered from a workflow that runs on your `master` branch after each commit or pull request merge.
+Typically this action is triggered from a workflow that runs on your `main` branch after each commit or pull request merge.
 
 Here's a sample release workflow:
 
@@ -13,7 +13,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   release:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node
         uses: Brightspace/third-party-actions@actions/setup-node
       - name: Incremental Release
-        uses: BrightspaceUI/actions/incremental-release@master
+        uses: BrightspaceUI/actions/incremental-release@main
         with:
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
 ```
@@ -65,7 +65,7 @@ Normally, if the most recent commit does not contain `[increment major|minor|pat
 In this example, a minor release will occur if no increment value is found in the most recent commit:
 
 ```yml
-uses: BrightspaceUI/actions/incremental-release@master
+uses: BrightspaceUI/actions/incremental-release@main
 with:
   DEFAULT_INCREMENT: minor
 ```
@@ -85,7 +85,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   release:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
@@ -101,7 +101,7 @@ jobs:
       # additional build/validation steps can be run here
       - name: Incremental Release
         id: release
-        uses: BrightspaceUI/actions/incremental-release@master
+        uses: BrightspaceUI/actions/incremental-release@main
         with:
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
       - name: Publish

--- a/prepare-translations-for-npm/README.md
+++ b/prepare-translations-for-npm/README.md
@@ -5,7 +5,7 @@ in your project that doesn't yet have a proper translation.
 
 ## Using the Action
 
-Typically this action is called from a release workflow before a step which publishes to NPM, such as the [semantic-release action](https://github.com/BrightspaceUI/actions/tree/master/semantic-release).
+Typically this action is called from a release workflow before a step which publishes to NPM, such as the [semantic-release action](https://github.com/BrightspaceUI/actions/tree/main/semantic-release).
 
 
 Here's a sample workflow:
@@ -15,7 +15,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   release:
     timeout-minutes: 2
@@ -29,7 +29,7 @@ jobs:
         uses: Brightspace/third-party-actions@actions/setup-node
         # additional validation steps can be run here
       - name: Prepare Translations for NPM
-        uses: BrightspaceUI/actions/prepare-translations-for-npm@master
+        uses: BrightspaceUI/actions/prepare-translations-for-npm@main
         with:
           LANG_PATH: lang
         # NPM publishing step happens here
@@ -47,6 +47,6 @@ Notes:
 
 This action expects the following format for lang files:
 * All lang files should be contained within the top level of the `LANG_PATH` directory. This action does not support language files within nested directories (e.g. `{LANG_PATH}/es/es.js`, `{LANG_PATH}/en/en.js` would not be supported).
-* Lang files must be JavaScript modules, formatted as outlined in the [localize mixin documentation](https://github.com/BrightspaceUI/core/blob/master/mixins/localize-mixin.md).
+* Lang files must be JavaScript modules, formatted as outlined in the [localize mixin documentation](https://github.com/BrightspaceUI/core/blob/main/mixins/localize-mixin.md).
 * Languages not included in the default list within the `prepare-translations.js` script within this action will not be prepared for translation. Please ensure any new languages are added to that list.
 * Language files with empty default exports should be created for all supported languages, even those that don't currently have translations. This action will not fail if language files are missing in your repo, but will also not attempt to prepare default translations for those languages.

--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -8,7 +8,7 @@ This GitHub action uses the [semantic-release](https://semantic-release.gitbook.
 
 ## Using the Action
 
-Typically this action is triggered from a workflow that runs on your `master` branch after each commit or pull request merge.
+Typically this action is triggered from a workflow that runs on your `main` branch after each commit or pull request merge.
 
 Here's a sample release workflow:
 
@@ -17,7 +17,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
       - '[0-9]+.x'
       - '[0-9]+.[0-9]+.x'
 jobs:
@@ -33,8 +33,9 @@ jobs:
       - name: Setup Node
         uses: Brightspace/third-party-actions@actions/setup-node
       - name: Semantic Release
-        uses: BrightspaceUI/actions/semantic-release@master
+        uses: BrightspaceUI/actions/semantic-release@main
         with:
+          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
           NPM: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -53,7 +54,7 @@ Outputs:
 
 Notes:
 * If you have additional release validation steps (e.g. build step, validation tests), run them after the "Setup Node" step and before the "Semantic Release" step.
-* This example will release only from `master` and maintenance branches (e.g. `1.15.x` or `2.x`) -- see more info about maintenance branches below.
+* This example will release only from `main` and maintenance branches (e.g. `1.15.x` or `2.x`) -- see more info about maintenance branches below.
 
 ### Branch Protection Rules and D2L_GITHUB_TOKEN
 

--- a/update-package-lock/README.md
+++ b/update-package-lock/README.md
@@ -23,9 +23,9 @@ jobs:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node
       - name: Update package-lock.json
-        uses: BrightspaceUI/actions/update-package-lock@master
+        uses: BrightspaceUI/actions/update-package-lock@main
         with:
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
 ```
 

--- a/update-package-lock/README.md
+++ b/update-package-lock/README.md
@@ -25,7 +25,6 @@ jobs:
       - name: Update package-lock.json
         uses: BrightspaceUI/actions/update-package-lock@main
         with:
-          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
 ```
 

--- a/visual-diff/README.md
+++ b/visual-diff/README.md
@@ -29,7 +29,7 @@ jobs:
         run: npm install
         # additional linting and testing steps here
       - name: Visual Diff Tests
-        uses: BrightspaceUI/actions/visual-diff@master
+        uses: BrightspaceUI/actions/visual-diff@main
         with:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -47,7 +47,7 @@ Options:
 * `TEST_TIMEOUT` (default: `40000`): Test timeout passed into the mocha call.
 
 Notes:
-* You can also run this action in your release workflow to confirm the `master` branch is in a good state before releasing.  If there's a problem, a PR will be opened against `master` to get the goldens back in the expected state.  This mostly comes down to a time versus risk trade-off - the risk of things getting out of sync may be lower than the time taken to run your visual diff tests every release.
+* You can also run this action in your release workflow to confirm the `main` branch is in a good state before releasing.  If there's a problem, a PR will be opened against `main` to get the goldens back in the expected state.  This mostly comes down to a time versus risk trade-off - the risk of things getting out of sync may be lower than the time taken to run your visual diff tests every release.
 * You can use the standard `GITHUB_TOKEN` that exists automatically, but will need to [setup the AWS secrets](#setting-up-aws-access-creds).
 
 ## Setting Up AWS Access Creds


### PR DESCRIPTION
As discussed, we're not going to change the default value for `DEFAULT_BRANCH` in the semantic-release actions because there are 100s of places using it currently.