### PR TITLE
ESM

### DIFF
--- a/incremental-release/create-release.js
+++ b/incremental-release/create-release.js
@@ -1,4 +1,4 @@
-const { Octokit } = require('@octokit/rest');
+import { Octokit } from '@octokit/rest';
 
 const release = `v${process.argv[2]}`;
 const [owner, repo] = process.env['GITHUB_REPOSITORY'].split('/');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@brightspace-ui/actions",
+  "version": "1.0.0",
+  "description": "Collection of GitHub Actions for use in Brightspace UI repositories",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BrightspaceUI/actions.git"
+  },
+  "author": "D2L Corporation",
+  "license": "Apache-2.0"
+}

--- a/prepare-translations-for-npm/action.yml
+++ b/prepare-translations-for-npm/action.yml
@@ -8,7 +8,7 @@ runs:
   using: composite
   steps:
     - name: Installing chalk
-      run: npm install --no-save --prefix ${{ github.action_path }} chalk@4
+      run: npm install --no-save --prefix ${{ github.action_path }} chalk@5
       shell: bash
     - name: Preparing translations
       run: node ${{ github.action_path }}/prepare-translations.js

--- a/prepare-translations-for-npm/prepare-translations.js
+++ b/prepare-translations-for-npm/prepare-translations.js
@@ -1,10 +1,10 @@
-const chalk = require('chalk'),
-	fs = require('fs');
+import chalk from 'chalk';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 
 const langs = ['ar', 'cy', 'da', 'de', 'es', 'es-es', 'fr', 'fr-fr', 'ja', 'ko', 'nl', 'pt', 'sv', 'tr', 'zh-tw', 'zh'];
 
 function _parseFile(filePath) {
-	const file = fs.readFileSync(filePath).toString();
+	const file = readFileSync(filePath).toString();
 	const firstBit = file.split('default ')[1];
 	const stringContent = firstBit.substring(0, firstBit.lastIndexOf(';'));
 	return JSON.parse(stringContent);
@@ -15,7 +15,7 @@ function _writeChanges(langTermsPath, fileName, content) {
 	const fileContent = `/* eslint quotes: 0 */
 export default ${json};
 `;
-	fs.writeFileSync(`${langTermsPath}/${fileName}.js`, fileContent, 'utf8');
+	writeFileSync(`${langTermsPath}/${fileName}.js`, fileContent, 'utf8');
 }
 
 function prepare(langTermsPath) {
@@ -25,7 +25,7 @@ function prepare(langTermsPath) {
 	langs.forEach((lang) => {
 		const filePath = `${langTermsPath}/${lang}.js`;
 
-		if (!fs.existsSync(filePath)) return;
+		if (!existsSync(filePath)) return;
 		
 		let changes = false;
 		const translations = _parseFile(filePath);

--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -35,6 +35,7 @@ jobs:
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@main
         with:
+          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
           NPM: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -35,7 +35,6 @@ jobs:
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@main
         with:
-          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
           NPM: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/update-package-lock/action.yml
+++ b/update-package-lock/action.yml
@@ -26,7 +26,7 @@ runs:
       - name: Install Dependencies
         run: |
           echo -e "\e[34mInstalling Dependencies"
-          npm install chalk@4 @octokit/graphql@4 --prefix ${{ github.action_path }} --no-save --loglevel error
+          npm install chalk@5 @octokit/graphql@4 --prefix ${{ github.action_path }} --no-save --loglevel error
         shell: bash
       - name: Checkout Branch
         run: |

--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const chalk = require('chalk');
-const { graphql } = require('@octokit/graphql');
+import chalk from 'chalk';
+import { graphql } from '@octokit/graphql';
 
 const [owner, repo] = process.env['GITHUB_REPOSITORY'].split('/');
 const approvalToken = process.env['APPROVAL_TOKEN'];

--- a/visual-diff/action.yml
+++ b/visual-diff/action.yml
@@ -34,7 +34,7 @@ runs:
         else
           npm install esm@3 --no-save
         fi
-        npm install chalk@4 @octokit/rest@18 --prefix ${{ github.action_path }} --no-save --loglevel error
+        npm install chalk@5 @octokit/rest@18 --prefix ${{ github.action_path }} --no-save --loglevel error
       env:
         FORCE_COLOR: 3
       shell: bash

--- a/visual-diff/cleanup-branches.js
+++ b/visual-diff/cleanup-branches.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const chalk = require('chalk');
-const { Octokit } = require('@octokit/rest');
+import chalk from 'chalk';
+import { Octokit } from '@octokit/rest';
 
 const octokit = new Octokit({
 	auth: process.env['GITHUB_TOKEN'],

--- a/visual-diff/handle-issues.js
+++ b/visual-diff/handle-issues.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const chalk = require('chalk');
-const { Octokit } = require('@octokit/rest');
+import chalk from 'chalk';
+import { Octokit } from '@octokit/rest';
 
 const octokit = new Octokit({
 	auth: process.env['GITHUB_TOKEN'],

--- a/visual-diff/handle-pr.js
+++ b/visual-diff/handle-pr.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const chalk = require('chalk');
-const { Octokit } = require('@octokit/rest');
+import chalk from 'chalk';
+import { Octokit } from '@octokit/rest';
 
 const [owner, repo] = process.env['GITHUB_REPOSITORY'].split('/');
 const actor = process.env['GITHUB_ACTOR'];


### PR DESCRIPTION
This makes the actions repo ESM-by-default and switches any JS files to use ESM import syntax. Upgrading to `chalk` version 5 which is ESM-only.