### PR TITLE
upgrading mocha, puppeteer and visual-diff

### DIFF
--- a/visual-diff/README.md
+++ b/visual-diff/README.md
@@ -3,7 +3,7 @@
 This GitHub action runs your repo's [visual diff tests](https://github.com/BrightspaceUI/visual-diff).  If the tests fail, a draft PR will be opened with the new goldens against the branch/PR that triggered the action.  If they pass, any open goldens PRs for that branch/PR will be closed for you.
 
 More specifically, this action will:
-* Install the `@brightspace-ui/visual-diff`, `esm`, `mocha` and `puppeteer` dependencies for you, so you don't need to include them in your local `devDependencies`
+* Install the `@brightspace-ui/visual-diff`, `mocha` and `puppeteer` dependencies for you, so you don't need to include them in your local `devDependencies`
 * Cleanup abandoned golden PRs
 * Run your visual diff tests and display the results (including links to the visual diff reports stored in S3)
 * If failures occurred, it will open/update the corresponding goldens PR with the new goldens and links to the failed reports

--- a/visual-diff/action.yml
+++ b/visual-diff/action.yml
@@ -30,9 +30,7 @@ runs:
         echo -e "\e[34mInstalling Dependencies"
         NPM_PACKAGE=$(cut -d "=" -f 2 <<< $(npm run env | grep "npm_package_name"))
         if [ $NPM_PACKAGE != '@brightspace-ui/visual-diff' ]; then
-          npm install esm@3 mocha@8 puppeteer@10 @brightspace-ui/visual-diff@6 --no-save
-        else
-          npm install esm@3 --no-save
+          npm install mocha@9 puppeteer@12 @brightspace-ui/visual-diff@7 --no-save
         fi
         npm install chalk@5 @octokit/rest@18 --prefix ${{ github.action_path }} --no-save --loglevel error
       env:


### PR DESCRIPTION
We're now ready to use the latest Mocha@9, Puppeteer@12 and visual-diff@7.