### PR TITLE
feat: allow .mjs extension

### DIFF
--- a/visual-diff/README.md
+++ b/visual-diff/README.md
@@ -43,7 +43,7 @@ Options:
 * `AWS_SESSION_TOKEN`: Session token for the role that will assume the visual diff role - see [setup details](#setting-up-aws-access-creds) below.
 * `DRAFT_PR` (default: `true`): Whether to open the goldens PR as a draft PR.
 * `GITHUB_TOKEN`: Token to use to open the goldens PR.  This does not need admin privileges, so you can use the standard `GITHUB_TOKEN` that exists automatically.
-* `TEST_PATH` (default: `./{,!(node_modules)/**}/*.visual-diff.js`): Path passed into the mocha call defining the locations and name structure of the tests.
+* `TEST_PATH` (default: `./{,!(node_modules)/**}/*.visual-diff.{js,mjs}`): Path passed into the mocha call defining the locations and name structure of the tests.
 * `TEST_TIMEOUT` (default: `40000`): Test timeout passed into the mocha call.
 
 Notes:

--- a/visual-diff/action.yml
+++ b/visual-diff/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: true
   TEST_PATH:
     description: Path passed into the mocha call defining the locations and name structure of the tests
-    default: './{,!(node_modules)/**}/*.visual-diff.js'
+    default: './{,!(node_modules)/**}/*.visual-diff.{js,mjs}'
   TEST_TIMEOUT:
     description: Test timeout passed into the mocha call
     default: 40000


### PR DESCRIPTION
There are certain repos that are just going to be too difficult to convert to be ESM-by-default. As an alternative, we can make the `*.visual-diff.js` files use the `.mjs` extension. That way Mocha will treat them as modules.

This change allows for that without teams needing to override the `TEST_PATH` themselves [like I did in the navigation repo(https://github.com/BrightspaceUI/navigation/blob/main/.github/workflows/visual-diff.yml#L22).