### PR TITLE
update-package-lock: update user config

### DIFF
--- a/update-package-lock/action.yml
+++ b/update-package-lock/action.yml
@@ -59,8 +59,8 @@ runs:
           rm -rf ./node_modules
           rm package-lock.json
           npm install
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git config user.name brightspace-bot
+          git config user.email 11837500+brightspace-bot@users.noreply.github.com
           git add package-lock.json
           git commit -m '${{ inputs.COMMIT_MESSAGE }}'
           git push --force origin ${{ inputs.BRANCH_NAME }}


### PR DESCRIPTION
I don't think this will fix the problem, but I just want to check.  Everywhere using this action will likely want to trigger ci, and they'll be passing in the brightspace-bot token.