### PR TITLE
fixing repositoryId type

### DIFF
--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -51,7 +51,7 @@ async function handlePR() {
 	let newPrId;
 	try {
 		const createPrResponse = await graphqlForPR(
-			`mutation createPR($repositoryId: String!, $head: String!, $base: String!, $title: String!, $body: String!) {
+			`mutation createPR($repositoryId: ID!, $head: String!, $base: String!, $title: String!, $body: String!) {
 				createPullRequest(input: {repositoryId: $repositoryId, headRefName: $head, baseRefName: $base, title: $title, body: $body}) {
 					pullRequest {
 						id


### PR DESCRIPTION
I'm not sure why this just started failing a few days ago, but we're seeing this error:
> Type mismatch on variable $repositoryId and argument repositoryId (String! / ID!)

Examples I'm finding online of calling this GraphQL API use `ID!` and not `String!`, so hopefully this fixes it.