### PR TITLE
switching pullRequestId to use ID type

### DIFF
--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -83,7 +83,7 @@ async function handlePR() {
 
 		try {
 			await graphqlForAutoMerge(
-				`mutation enableAutoMerge($pullRequestId: String!) {
+				`mutation enableAutoMerge($pullRequestId: ID!) {
 					enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId }) {
 						clientMutationId
 					}
@@ -108,7 +108,7 @@ async function handlePR() {
 
 		try {
 			await graphqlForApproval(
-				`mutation approvePR($pullRequestId: String!) {
+				`mutation approvePR($pullRequestId: ID!) {
 					addPullRequestReview(input: {pullRequestId: $pullRequestId}) {
 						clientMutationId
 					}


### PR DESCRIPTION
So now we're getting:
>  Type mismatch on variable $pullRequestId and argument pullRequestId (String! / ID!)