### PR TITLE
Escaped the branch name

### DIFF
--- a/visual-diff/action.yml
+++ b/visual-diff/action.yml
@@ -66,7 +66,7 @@ runs:
       id: committing-goldens
       run: |
         if [ ${{ github.event.number }} ]; then
-          SOURCE_BRANCH=${{ github.event.pull_request.head.ref }}
+          SOURCE_BRANCH='${{ github.event.pull_request.head.ref }}'
           VISUAL_DIFF_BRANCH=ghworkflow/visual-diff-pr-${{ github.event.number }}
           ORIGINAL_SHA=${{ github.event.pull_request.head.sha }}
         else


### PR DESCRIPTION
If a branch name contains a special character like a bracket it can cause the vdiff action to fail, see here https://github.com/Brightspace/d2l-rubric/pull/1691. Escaping the branch name should fix this problem. 

Note: This is a low risk change but I am not sure how I can test it locally, if anyone has suggestions I can try testing it before we merge this. 