### PR TITLE
Auto-generate Release notes if possible

### DIFF
--- a/incremental-release/create-release.js
+++ b/incremental-release/create-release.js
@@ -15,7 +15,8 @@ async function createRelease() {
 		owner: owner,
 		repo: repo,
 		tag_name: release,
-		name: release
+		name: release,
+		generate_release_notes: true
 	});
 	console.log('Success!');
 


### PR DESCRIPTION
Using incremental release means all releases descriptions in GitHub look like this:

![image](https://user-images.githubusercontent.com/15062048/156694790-f637be50-3dcb-42ca-9362-166724e55590.png)

The `generate_release_notes` property will:
> Whether to automatically generate the name and body for this release. If `name` is specified, the specified `name` will be used; otherwise, a `name` will be automatically generated. If `body` is specified, the `body` will be pre-pended to the automatically generated notes.

It will pick up a template if specified in the repo: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configuration

Octokit: https://octokit.github.io/rest.js/v18#repos-create-release
![image](https://user-images.githubusercontent.com/15062048/156695249-2db04108-cb56-44bc-8243-bf73773e7489.png)

https://docs.github.com/en/enterprise-server@3.3/rest/reference/releases#create-a-release--parameters

