### PR TITLE
Add `NODE_AUTH_TOKEN`

### DIFF
--- a/update-package-lock/README.md
+++ b/update-package-lock/README.md
@@ -36,7 +36,8 @@ Options:
 * `APPROVAL_TOKEN`: Token to auto-approve the PR after opening. If no token is passed, the auto-approval will be skipped. See [setup details](#setting-up-auto-approval) below.
 * `AUTO_MERGE_TOKEN`: Token to enable auto-merge on the PR. If no token is passed, the auto-merge will be skipped. See [setup details](#setting-up-auto-merge) below.
 * `BRANCH_NAME` (default: `ghworkflow/package_lock_auto_update`): Name of the branch to add the changes to and open the pull request from.
-* `CODEARTIFACT_AUTH_TOKEN`: Token for reading @d2l packages from CodeArtifact. If no token is passed, any attempts at installing private packages from CodeArtifact will fail with a 401 error.
+* `NODE_AUTH_TOKEN`: Token for reading packages from already setup private registry
+* `CODEARTIFACT_AUTH_TOKEN`: Token for reading @d2l packages from CodeArtifact. If no token is passed, any attempts at installing private packages from CodeArtifact will fail with a 401 error (deprecated, use `NODE_AUTH_TOKEN` instead).
 * `COMMIT_MESSAGE` (default: `Auto Update Dependencies`): Commit message for the changes.
 * `DEFAULT_BRANCH` (default: `main`): Name of the default release branch for your repo.
 * `GITHUB_TOKEN` (required): Token for opening the updates PR. See [setup details](#setting-github-token) below.

--- a/update-package-lock/action.yml
+++ b/update-package-lock/action.yml
@@ -29,6 +29,7 @@ runs:
   steps:
       - name: Determine Token
         id: token
+        shell: bash
         run: |
           TOKEN="$NODE_AUTH_TOKEN"
           TOKEN=${TOKEN:-"$CODEARTIFACT_AUTH_TOKEN"}

--- a/update-package-lock/action.yml
+++ b/update-package-lock/action.yml
@@ -10,6 +10,8 @@ inputs:
     default: ghworkflow/package_lock_auto_update
   CODEARTIFACT_AUTH_TOKEN:
     description: Token for reading @d2l packages from CodeArtifact
+  NODE_AUTH_TOKEN:
+    description: Token for reading packages from already setup private registry
   COMMIT_MESSAGE:
     description: Commit message for the update
     default: 'Auto Update Dependencies'
@@ -25,6 +27,15 @@ inputs:
 runs:
   using: composite
   steps:
+      - name: Determine Token
+        id: token
+        run: |
+          TOKEN="$NODE_AUTH_TOKEN"
+          TOKEN=${TOKEN:-"$CODEARTIFACT_AUTH_TOKEN"}
+          echo "::set-output name=NODE_AUTH_TOKEN::$TOKEN"
+        env:
+          CODEARTIFACT_AUTH_TOKEN: ${{inputs.CODEARTIFACT_AUTH_TOKEN}}
+          NODE_AUTH_TOKEN: ${{inputs.NODE_AUTH_TOKEN}}
       - name: Install Dependencies
         run: |
           echo -e "\e[34mInstalling Dependencies"
@@ -43,7 +54,7 @@ runs:
           rm package-lock.json
           npm install
         env:
-          CODEARTIFACT_AUTH_TOKEN: ${{ inputs.CODEARTIFACT_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ steps.token.outputs.NODE_AUTH_TOKEN }}
         shell: bash
       - name: Check For Changes
         id: check-for-changes
@@ -70,7 +81,7 @@ runs:
           git push --force https://${GITHUB_TOKEN}@github.com/${{ github.repository }} ${{ inputs.BRANCH_NAME }}
         env:
           GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-          CODEARTIFACT_AUTH_TOKEN: ${{ inputs.CODEARTIFACT_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ steps.token.outputs.NODE_AUTH_TOKEN }}
         shell: bash
       - name: Create PR (if necessary)
         run: |


### PR DESCRIPTION
Will fallback to `CODEARTIFACT_AUTH_TOKEN` if not available. Working towards getting BSI to work with the standard private registry setup via the `setup-node` action (https://github.com/Brightspace/brightspace-integration/pull/5942).