### PR TITLE
Add DEFAULT_BRANCH_PRERELEASE

### DIFF
--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -42,7 +42,8 @@ jobs:
 
 Options:
 
-* `DEFAULT_BRANCH` (default: `"main"`): name of the default release branch
+* `DEFAULT_BRANCH` (default: `"main"`): Name of the default release branch
+* `DEFAULT_BRANCH_PRERELEASE` (default: `false`): Whether or not to create a prerelease on the default branch
 * `DRY_RUN` (default: `false`): Runs semantic-release with the `--dry-run` flag to simulate a release but not actually do one
 * `GITHUB_TOKEN`: Token to use to update version in 'package.json' and create GitHub release -- see section below on branch protection for more details
 * `NPM` (default: `false`): Whether or not to release as an NPM package (see "NPM Package Deployment" below for more info)

--- a/semantic-release/action.yml
+++ b/semantic-release/action.yml
@@ -2,8 +2,11 @@ name: Semantic Release
 description: Deploy using semantic-release
 inputs:
   DEFAULT_BRANCH:
-    description: name of the default release branch
+    description: Name of the default release branch
     default: main
+  DEFAULT_BRANCH_PRERELEASE:
+    description: Whether or not to create a prerelease on the default branch
+    default: false
   DRY_RUN:
     description: Runs semantic-release with the "--dry-run" flag to simulate a release but not actually do one
     default: false

--- a/semantic-release/create-config.sh
+++ b/semantic-release/create-config.sh
@@ -4,11 +4,16 @@ if [ "$IS_TRACKED" != "" ]; then
 else
   ASSETS="[\"package.json\"]"
 fi
+if [ $DEFAULT_BRANCH_PRERELEASE == "true" ] || [ $DEFAULT_BRANCH_PRERELEASE == "TRUE" ] || [ $DEFAULT_BRANCH_PRERELEASE == true ]; then
+  PRERELEASE=true
+else
+  PRERELEASE=false
+fi
 cat >$FILE_PATH <<EOL
 {
   "branches": [
     "+([0-9])?(.{+([0-9]),x}).x",
-    "$DEFAULT_BRANCH",
+    {"name": "$DEFAULT_BRANCH", "prerelease": PRERELEASE},
     "next",
     "next-major",
     {"name": "beta", "prerelease": true},


### PR DESCRIPTION
**The problem**
I'm trying to integrate `semantic-release` into the CI pipeline for our services. Currently, every merge to `master` gets deployed to the `dev` stage and we create a release when we want to deploy to `prod`. Unfortunately, we will end up with `prod` deployments on every merge by switching to `semantic-release`.

**The solution**
I'm totally open to other suggestions but my change allows us to create pre-releases on merge to `master` (with only `dev` deployment) and just marking them as "ready for release" when we want a `prod` deployment. Another option would be to allow overriding `branches` config but I can't think of a nice way to achieve that without overriding the whole semantic-release config.