### PR TITLE
Use `rest` in property chain to make it work

### DIFF
--- a/incremental-release/create-release.js
+++ b/incremental-release/create-release.js
@@ -11,7 +11,7 @@ async function createRelease() {
 
 	console.log(`Creating release "${release}"...`)
 
-	await octokit.repos.createRelease({
+	await octokit.rest.repos.createRelease({
 		owner: owner,
 		repo: repo,
 		tag_name: release,


### PR DESCRIPTION
It turns out the release notes weren't generating without using the `rest` property to do so. The docs actually show it but I missed it out thinking: 
`octokit.rest.repos.createRelease({` would be the same as `octokit.repos.createRelease({` in functionality.

https://octokit.github.io/rest.js/v18#repos-create-release

See the `d2l-class-stream` now with release notes:
https://github.com/Brightspace/d2l-class-stream/commit/b2b9212a809d70c227a57f66592b968b4f25418e
![image](https://user-images.githubusercontent.com/15062048/160509389-70052a24-d78a-4763-93a7-439ee678dfed.png)
