### PR TITLE
Avoid an adjacent link to less details docs

### DIFF
--- a/visual-diff/README.md
+++ b/visual-diff/README.md
@@ -52,7 +52,7 @@ Notes:
 
 ## Setting Up AWS Access Creds
 
-In order to have the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` available to you, you will need to add that info to your repo setup in [`repo-settings`](https://github.com/Brightspace/repo-settings).  [See the documentation](https://github.com/Brightspace/repo-settings/blob/main/docs/visual-diff.md).
+In order to have the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` available to you, you will need to add that info to your repo setup in repo-settings.  [See the documentation](https://github.com/Brightspace/repo-settings/blob/main/docs/visual-diff.md).
 
 ## Removing CODEOWNER Restrictions for Golden Update PRs
 


### PR DESCRIPTION
Sorry; I didn't notice until after merge that these two links were side-by-side.
My thought here is its better to deep-link and it would be easy to "mis-click" the first link.