### PR TITLE
adding NPM support to incremental-release

### DIFF
--- a/incremental-release/README.md
+++ b/incremental-release/README.md
@@ -1,6 +1,6 @@
 # Incremental Release Action
 
-This GitHub action looks for keywords in the latest commit to automatically increment the package version and create a tag.
+This GitHub action looks for keywords in the latest commit to automatically increment the package version, create a GitHub release/tag and optionally publish to NPM.
 
 ## Using the Action
 
@@ -36,6 +36,8 @@ Options:
 * `DEFAULT_INCREMENT` (default: `skip`): If no release keyword is found in the latest commit message, this value will be used to trigger a release. Can be one of: `skip`, `patch`, `minor`, `major`.
 * `DRY_RUN` (default: `false`): Simulates a release but does not actually do one
 * `GITHUB_TOKEN`: Token to use to update version in 'package.json' and create the tag -- see section below on branch protection for more details
+* `NPM` (default: `false`): Whether or not to release as an NPM package (see "NPM Package Deployment" below for more info)
+* `NPM_TOKEN` (optional if `NPM` is `false` or publishing to CodeArtifact): Token to publish to NPM (see "NPM Package Deployment" below for more info)
 
 Outputs:
 * `VERSION`: will contain the new version number if a release occurred, empty otherwise
@@ -48,6 +50,47 @@ Notes:
 The release step will fail to write to `package.json` if you have branch protection rules set up in your repository. To get around this, we use a special Admin `D2L_GITHUB_TOKEN`.
 
 [Learn how to set up the D2L_GITHUB_TOKEN...](../docs/branch-protection.md)
+
+## NPM Package Deployment
+
+If you'd like the action to deploy your package to NPM, set the `NPM` option to `true`.
+
+### CodeArtifact
+
+To publish to CodeArtifact, ensure that prior to running the `incremental-release` step that the [add-registry](https://github.com/Brightspace/codeartifact-actions/tree/main/npm) and the [get-authorization-token](https://github.com/Brightspace/codeartifact-actions/tree/main/get-authorization-token) steps have been run.
+
+### NPM
+
+Setup Node with the `registry-url` option:
+
+```yml
+- name: Setup Node
+  uses: Brightspace/third-party-actions@actions/setup-node
+    with:
+     registry-url: 'https://registry.npmjs.org'
+```
+
+Then pass through the `NPM_TOKEN` secret.
+
+```yml
+- name: Incremental Release
+  uses: BrightspaceUI/actions/incremental-release@main
+    with:
+      NPM: true
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+`NPM_TOKEN` is available as a shared organization secret in the `Brightspace`, `BrightspaceUI`, `BrightspaceUILabs` and `BrightspaceHypermediaComponents` organizations.
+
+If your package is being published under the `@brightspace-ui` or `@brightspace-ui-labs` NPM organizations, ensure that it has the proper configuration in its `package.json`:
+
+```json
+"publishConfig": {
+  "access": "public"
+}
+```
+
+Also ensure that `"private": true` is not present.
 
 ## Triggering a Release
 

--- a/incremental-release/action.yml
+++ b/incremental-release/action.yml
@@ -10,6 +10,11 @@ inputs:
   GITHUB_TOKEN:
     description: Token to use to update version in 'package.json' and create the tag
     required: true
+  NPM:
+    description: Whether or not to release as an NPM package
+    default: false
+  NPM_TOKEN:
+    description: Token to publish to NPM
 outputs:
   VERSION:
     description: Version of the new release
@@ -80,4 +85,16 @@ runs:
         node ${{ github.action_path }}/create-release.js ${{ steps.increment-version.outputs.version }}
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+      shell: bash
+    - name: Publish to NPM
+        if [ ${{ steps.determine-increment.outputs.increment }} == "skip" || ${{ inputs.NPM }} == false ]; then
+          exit 0;
+        fi
+        if [ ${{ inputs.DRY_RUN }} == true ]; then
+          npm publish --dry-run
+        else
+          npm publish
+        fi
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}
       shell: bash

--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -36,8 +36,6 @@ jobs:
         uses: BrightspaceUI/actions/semantic-release@main
         with:
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
-          NPM: true
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
 
 Options:
@@ -63,7 +61,36 @@ The release step will fail to write to `package.json` if you have branch protect
 
 ## NPM Package Deployment
 
-If you'd like the action to deploy your package to NPM, set the `NPM` option to `true` and pass through the `NPM_TOKEN` secret. `NPM_TOKEN` is available automatically as a shared organization secret in the `BrightspaceUI`, `BrightspaceUILabs` and `BrightspaceHypermediaComponents` organizations.
+If you'd like the action to deploy your package to NPM, set the `NPM` option to `true`.
+
+### CodeArtifact
+
+To publish to CodeArtifact, ensure that prior to running the `semantic-release` step that the [add-registry](https://github.com/Brightspace/codeartifact-actions/tree/main/npm) and the [get-authorization-token](https://github.com/Brightspace/codeartifact-actions/tree/main/get-authorization-token) steps have been run.
+
+Then, pass through the `CODEARTIFACT_AUTH_TOKEN` as `NPM_TOKEN`:
+
+```yml
+- name: Semantic Release
+  uses: BrightspaceUI/actions/semantic-release@main
+  with:
+    NPM: true
+    NPM_TOKEN: ${{ env.CODEARTIFACT_AUTH_TOKEN }}
+```
+
+### NPM
+
+Simply pass through the `NPM_TOKEN` secret.
+
+
+```yml
+- name: Semantic Release
+  uses: BrightspaceUI/actions/semantic-release@main
+    with:
+      NPM: true
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+`NPM_TOKEN` is available as a shared organization secret in the `Brightspace`, `BrightspaceUI`, `BrightspaceUILabs` and `BrightspaceHypermediaComponents` organizations.
 
 If your package is being published under the `@brightspace-ui` or `@brightspace-ui-labs` NPM organizations, ensure that it has the proper configuration in its `package.json`:
 


### PR DESCRIPTION
I think we'll just have to test this out in an actual repo when we convert one over.

I'm not super happy with how different NPM publishing with `semantic-release` is vs. `incremental-release`, which is why their READMEs are _almost_ the same but not similar enough to create a new doc that they both share.

The weirdness comes from the fact that our step to setup the CodeArtifact NPM registry [essentially modifies your local .npmrc file](https://github.com/Brightspace/codeartifact-actions/blob/main/npm/add-registry/action.yml#L20) to use the `CODEARTIFACT_AUTH_TOKEN` as the NPM auth token.

That's a little magical, but it's why `npm publish` "just works". That makes `incremental-release` easy (we just call `npm publish`), but unfortunately `semantic-release` is [doing something similar](https://github.com/semantic-release/npm/blob/7338fc25de82058ea83b1e6e6669707036c2d96a/lib/set-npmrc-auth.js#L41) but it uses the `NPM_TOKEN` that you pass it -- so we need to marshall the CodeArtifact one through there.

One alternative we could try is to just always pass `false` to `semantic-release` and then do the NPM publishing ourselves, which would make the incremental and semantic setups the same. Thoughts?