### PR TITLE
Revert "adding NPM support to incremental-release (#75)"

### DIFF
--- a/incremental-release/README.md
+++ b/incremental-release/README.md
@@ -1,6 +1,6 @@
 # Incremental Release Action
 
-This GitHub action looks for keywords in the latest commit to automatically increment the package version, create a GitHub release/tag and optionally publish to NPM.
+This GitHub action looks for keywords in the latest commit to automatically increment the package version and create a tag.
 
 ## Using the Action
 
@@ -36,8 +36,6 @@ Options:
 * `DEFAULT_INCREMENT` (default: `skip`): If no release keyword is found in the latest commit message, this value will be used to trigger a release. Can be one of: `skip`, `patch`, `minor`, `major`.
 * `DRY_RUN` (default: `false`): Simulates a release but does not actually do one
 * `GITHUB_TOKEN`: Token to use to update version in 'package.json' and create the tag -- see section below on branch protection for more details
-* `NPM` (default: `false`): Whether or not to release as an NPM package (see "NPM Package Deployment" below for more info)
-* `NPM_TOKEN` (optional if `NPM` is `false` or publishing to CodeArtifact): Token to publish to NPM (see "NPM Package Deployment" below for more info)
 
 Outputs:
 * `VERSION`: will contain the new version number if a release occurred, empty otherwise
@@ -50,47 +48,6 @@ Notes:
 The release step will fail to write to `package.json` if you have branch protection rules set up in your repository. To get around this, we use a special Admin `D2L_GITHUB_TOKEN`.
 
 [Learn how to set up the D2L_GITHUB_TOKEN...](../docs/branch-protection.md)
-
-## NPM Package Deployment
-
-If you'd like the action to deploy your package to NPM, set the `NPM` option to `true`.
-
-### CodeArtifact
-
-To publish to CodeArtifact, ensure that prior to running the `incremental-release` step that the [add-registry](https://github.com/Brightspace/codeartifact-actions/tree/main/npm) and the [get-authorization-token](https://github.com/Brightspace/codeartifact-actions/tree/main/get-authorization-token) steps have been run.
-
-### NPM
-
-Setup Node with the `registry-url` option:
-
-```yml
-- name: Setup Node
-  uses: Brightspace/third-party-actions@actions/setup-node
-    with:
-     registry-url: 'https://registry.npmjs.org'
-```
-
-Then pass through the `NPM_TOKEN` secret.
-
-```yml
-- name: Incremental Release
-  uses: BrightspaceUI/actions/incremental-release@main
-    with:
-      NPM: true
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-```
-
-`NPM_TOKEN` is available as a shared organization secret in the `Brightspace`, `BrightspaceUI`, `BrightspaceUILabs` and `BrightspaceHypermediaComponents` organizations.
-
-If your package is being published under the `@brightspace-ui` or `@brightspace-ui-labs` NPM organizations, ensure that it has the proper configuration in its `package.json`:
-
-```json
-"publishConfig": {
-  "access": "public"
-}
-```
-
-Also ensure that `"private": true` is not present.
 
 ## Triggering a Release
 

--- a/incremental-release/action.yml
+++ b/incremental-release/action.yml
@@ -10,11 +10,6 @@ inputs:
   GITHUB_TOKEN:
     description: Token to use to update version in 'package.json' and create the tag
     required: true
-  NPM:
-    description: Whether or not to release as an NPM package
-    default: false
-  NPM_TOKEN:
-    description: Token to publish to NPM
 outputs:
   VERSION:
     description: Version of the new release
@@ -85,16 +80,4 @@ runs:
         node ${{ github.action_path }}/create-release.js ${{ steps.increment-version.outputs.version }}
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-      shell: bash
-    - name: Publish to NPM
-        if [ ${{ steps.determine-increment.outputs.increment }} == "skip" || ${{ inputs.NPM }} == false ]; then
-          exit 0;
-        fi
-        if [ ${{ inputs.DRY_RUN }} == true ]; then
-          npm publish --dry-run
-        else
-          npm publish
-        fi
-      env:
-        NODE_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}
       shell: bash

--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -36,6 +36,8 @@ jobs:
         uses: BrightspaceUI/actions/semantic-release@main
         with:
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
+          NPM: true
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
 
 Options:
@@ -61,36 +63,7 @@ The release step will fail to write to `package.json` if you have branch protect
 
 ## NPM Package Deployment
 
-If you'd like the action to deploy your package to NPM, set the `NPM` option to `true`.
-
-### CodeArtifact
-
-To publish to CodeArtifact, ensure that prior to running the `semantic-release` step that the [add-registry](https://github.com/Brightspace/codeartifact-actions/tree/main/npm) and the [get-authorization-token](https://github.com/Brightspace/codeartifact-actions/tree/main/get-authorization-token) steps have been run.
-
-Then, pass through the `CODEARTIFACT_AUTH_TOKEN` as `NPM_TOKEN`:
-
-```yml
-- name: Semantic Release
-  uses: BrightspaceUI/actions/semantic-release@main
-  with:
-    NPM: true
-    NPM_TOKEN: ${{ env.CODEARTIFACT_AUTH_TOKEN }}
-```
-
-### NPM
-
-Simply pass through the `NPM_TOKEN` secret.
-
-
-```yml
-- name: Semantic Release
-  uses: BrightspaceUI/actions/semantic-release@main
-    with:
-      NPM: true
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-```
-
-`NPM_TOKEN` is available as a shared organization secret in the `Brightspace`, `BrightspaceUI`, `BrightspaceUILabs` and `BrightspaceHypermediaComponents` organizations.
+If you'd like the action to deploy your package to NPM, set the `NPM` option to `true` and pass through the `NPM_TOKEN` secret. `NPM_TOKEN` is available automatically as a shared organization secret in the `BrightspaceUI`, `BrightspaceUILabs` and `BrightspaceHypermediaComponents` organizations.
 
 If your package is being published under the `@brightspace-ui` or `@brightspace-ui-labs` NPM organizations, ensure that it has the proper configuration in its `package.json`:
 


### PR DESCRIPTION
This reverts commit 4f846c0877d0a3eb642ea8a9b441224a0f5031e4.

It was causing issues as I forgot the `run: |` section, but we're also now not sure we even need this so I'm just removing it entirely for now.