### PR TITLE
Add get-maintenance-version action

### DIFF
--- a/get-maintenance-version/README.md
+++ b/get-maintenance-version/README.md
@@ -13,7 +13,7 @@ Include this action at any point before its data is required, and retrieve the d
 - name: Some other action
   run: |
     echo "Maintenance version: ${{ steps.get-maintenance-version.outputs.MAINTENANCE_VERSION }}"
-    [ ${{ inputs.AUTO_MAINTENANCE_BRANCH }} == true ] && echo "Is a maintenance branch"
+    [ ${{ steps.get-maintenance-version.outputs.IS_MAINTENANCE_BRANCH }} == true ] && echo "Is a maintenance branch"
 - name: Only runs on non-maintenance branches
   if: ${{ steps.get-maintenance-version.outputs.IS_MAINTENANCE_BRANCH != 'true' }}
   run: echo "Not a maintenance branch"

--- a/get-maintenance-version/README.md
+++ b/get-maintenance-version/README.md
@@ -1,0 +1,24 @@
+# Get Maintenance Version Action
+
+This GitHub action determines whether the current branch is for a maintenance version (e.g. `release/2022.2.x`, `1.7.x`, or `1.x`), and if so, reports the detected maintenance version (e.g. `2022.2.x`, `1.7.x`, or `1.x`).
+
+## Using the Action
+
+Include this action at any point before its data is required, and retrieve the data with `outputs.MAINTENANCE_VERSION` and/or `outputs.IS_MAINTENANCE_BRANCH`:
+
+```yml
+- name: Get maintenance version
+  uses: BrightspaceUI/actions/get-maintenance-version@main
+  id: get-maintenance-version
+- name: Some other action
+  run: |
+    echo "Maintenance version: ${{ steps.get-maintenance-version.outputs.MAINTENANCE_VERSION }}"
+    [ ${{ inputs.AUTO_MAINTENANCE_BRANCH }} == true ] && echo "Is a maintenance branch"
+- name: Only runs on non-maintenance branches
+  if: ${{ steps.get-maintenance-version.outputs.IS_MAINTENANCE_BRANCH != 'true' }}
+  run: echo "Not a maintenance branch"
+```
+
+Outputs:
+* `MAINTENANCE_VERSION`: Maintenance version of the current branch, or empty string
+* `IS_MAINTENANCE_BRANCH`: Whether the current branch is a maintenance branch

--- a/get-maintenance-version/action.yml
+++ b/get-maintenance-version/action.yml
@@ -1,0 +1,18 @@
+name: Get Maintenance Version
+description: Detect the maintenance version from the current branch name, if any
+outputs:
+  MAINTENANCE_VERSION:
+    description: Maintenance version of the current branch
+    value: ${{ steps.main.outputs.MAINTENANCE_VERSION }}
+  IS_MAINTENANCE_BRANCH:
+    description: Whether the current branch is a maintenance branch
+    value: ${{ steps.main.outputs.MAINTENANCE_VERSION != '' }}
+runs:
+  using: composite
+  steps:
+    - id: main
+      run: |
+        MAINTENANCE_VERSION=$(echo "${GITHUB_REF##*/}" | grep -Eo "^[0-9]+\.([0-9]+\.)?x$" || true)
+        echo "Maintenance version determined from branch name: $MAINTENANCE_VERSION"
+        echo "::set-output name=MAINTENANCE_VERSION::$MAINTENANCE_VERSION"
+      shell: bash


### PR DESCRIPTION
This is a generic action that can be reused for checking whether the current branch is a "maintenance branch" and getting the matching maintenance version.

It's a prerequisite for getting translations merged into BSI (and the LMS) for 2022.7. This is the plan:

1. Add this action
2. Update the `semantic-release` action to skip the `MINOR_RELEASE_WITH_LMS` steps when it's a maintenance branch
3. On BrightspaceUI/core, delete and recreate branch `2.25.x` - this should retrigger the action, with this change, causing a patch version bump and release

Rally: https://rally1.rallydev.com/#/?detail=/userstory/641415440391&fdp=true