### PR TITLE
Skip minor release on maintenance branches

### DIFF
--- a/semantic-release/action.yml
+++ b/semantic-release/action.yml
@@ -32,19 +32,22 @@ runs:
         echo "Installing semantic-release..."
         npm install semantic-release@17 @semantic-release/git@9 --no-save
       shell: bash
+    - name: Get maintenance version
+      uses: BrightspaceUI/actions/get-maintenance-version@main
+      id: get-maintenance-version
     - name: Get Repo's Last LMS Release
-      if: ${{ inputs.MINOR_RELEASE_WITH_LMS == 'true' }}
+      if: ${{ inputs.MINOR_RELEASE_WITH_LMS == 'true' && steps.get-maintenance-version.IS_MAINTENANCE_VERSION != 'true' }}
       id: repo-lms-version
       run: echo "::set-output name=value::$(cat .lmsrelease)"
       shell: bash
     - name: Get Active LMS Release
-      if: ${{ inputs.MINOR_RELEASE_WITH_LMS == 'true' }}
+      if: ${{ inputs.MINOR_RELEASE_WITH_LMS == 'true' && steps.get-maintenance-version.IS_MAINTENANCE_VERSION != 'true' }}
       id: get-lms-version
       uses: Brightspace/lms-version-actions/get-lms-release@main
       with:
         RALLY_API_KEY: ${{ inputs.RALLY_API_KEY }}
     - name: Update Repo's Last LMS Release
-      if: ${{ inputs.MINOR_RELEASE_WITH_LMS == 'true' && inputs.DRY_RUN == 'false' && steps.repo-lms-version.outputs.VALUE != steps.get-lms-version.outputs.LMS_VERSION }}
+      if: ${{ inputs.MINOR_RELEASE_WITH_LMS == 'true' && steps.get-maintenance-version.IS_MAINTENANCE_VERSION != 'true' && inputs.DRY_RUN == 'false' && steps.repo-lms-version.outputs.VALUE != steps.get-lms-version.outputs.LMS_VERSION }}
       run: |
         echo "Updating last LMS release..."
         echo "${{ steps.get-lms-version.outputs.LMS_VERSION }}" > .lmsrelease


### PR DESCRIPTION
This is a follow-up to #83.

Adding the `IS_MAINTENACE_VERSION` check individually to each step isn't the cleanest, but it follows what's being done already with `MINOR_RELEASE_WITH_LMS`. The alternative would be moving that chunk of steps to its own action, and controlling whether to run the whole action with those two checks.

Rally: https://rally1.rallydev.com/#/?detail=/userstory/641415440391&fdp=true