### PR TITLE
Adjust auto merge message

### DIFF
--- a/update-package-lock/README.md
+++ b/update-package-lock/README.md
@@ -66,4 +66,4 @@ Like with [setting the `GITHUB_TOKEN` above](#setting-github-token), setting `AU
 
 ### Auto-Merge Method
 
-When using `AUTO_MERGE_METHOD` you must make sure the repository allows the method of merge selected, otherwise enabling auto merge will fail. By default all new repositories allow `merge` as the merge method hence the default for `AUTO_MERGE_METHOD`. For the merge method `squash` the value of `COMMIT_MESSAGE` will always be used as the [squash merge message](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#merge-message-for-a-squash-merge) as we will fall into the `one commit` section of the selection process at auto-merge enablement time.
+When using `AUTO_MERGE_METHOD` you must make sure the repository allows the method of merge selected, otherwise enabling auto merge will fail. By default all new repositories allow `merge` as the merge method hence the default for `AUTO_MERGE_METHOD`. For the merge method `squash` the value of `COMMIT_MESSAGE` will always be used as the squash merge message.

--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -10,6 +10,7 @@ const branchName = process.env['BRANCH_NAME'];
 const defaultBranch = process.env['DEFAULT_BRANCH'];
 const prTitle = process.env['PR_TITLE'];
 const autoMergeMethod = process.env['AUTO_MERGE_METHOD'];
+const commitMessage  = process.env['COMMIT_MESSAGE'];
 
 const graphqlForPR = graphql.defaults({
 	headers: {
@@ -90,17 +91,20 @@ async function handlePR() {
 
 		try {
 			await graphqlForAutoMerge(
-				`mutation enableAutoMerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+				`mutation enableAutoMerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!, $commitHeadline: String!) {
 					enablePullRequestAutoMerge(input: {
 						pullRequestId: $pullRequestId,
-						mergeMethod: $mergeMethod
+						mergeMethod: $mergeMethod,
+						commitHeadline: $commitHeadline,
+						commitBody: ''
 					}) {
 						clientMutationId
 					}
 				}`,
 				{
 					pullRequestId: newPrId,
-					mergeMethod: mergeMethod
+					mergeMethod: mergeMethod,
+					commitHeadline: commitMessage
 				}
 			);
 			console.log('PR set to auto-merge');


### PR DESCRIPTION
Since the `Default to PR title for squash merge commits` option now exists what is used as the auto merge method can vary and no longer matches the documentation. Adjust to always use the commit message for consistency.