### PR TITLE
feat: Add npm publish with tags to incremental-release

### DIFF
--- a/get-maintenance-version/README.md
+++ b/get-maintenance-version/README.md
@@ -1,6 +1,6 @@
 # Get Maintenance Version Action
 
-This GitHub action determines whether the current branch is for a maintenance version (e.g. `release/2022.2.x`, `1.7.x`, or `1.x`), and if so, reports the detected maintenance version (e.g. `2022.2.x`, `1.7.x`, or `1.x`).
+This GitHub action determines whether the current branch is for a maintenance version (e.g. `release/2022.2.x`, `1.7.x`, `1.x`, `release/1.7`, etc.), and if so, reports the detected maintenance version (e.g. `2022.2.x`, `1.7.x`, `1.x`, `1.7`).
 
 ## Using the Action
 

--- a/get-maintenance-version/action.yml
+++ b/get-maintenance-version/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - id: main
       run: |
-        MAINTENANCE_VERSION=$(echo "${GITHUB_REF##*/}" | grep -Eo "^[0-9]+\.([0-9]+\.)?x$" || true)
+        MAINTENANCE_VERSION=$(echo "${GITHUB_REF##*/}" | grep -Eo "^[0-9]+(\.[0-9]+)?(\.x)?$" || true)
         echo "Maintenance version determined from branch name: $MAINTENANCE_VERSION"
         echo "::set-output name=MAINTENANCE_VERSION::$MAINTENANCE_VERSION"
       shell: bash

--- a/incremental-release/action.yml
+++ b/incremental-release/action.yml
@@ -10,6 +10,13 @@ inputs:
   GITHUB_TOKEN:
     description: Token to use to update version in 'package.json' and create the tag
     required: true
+  NPM:
+    description: Whether or not to release as an NPM package
+    default: false
+    required: false
+  NPM_TOKEN:
+    description: Token to publish to NPM
+    required: false
 outputs:
   VERSION:
     description: Version of the new release
@@ -19,11 +26,12 @@ runs:
   steps:
     - name: Install Dependencies
       run: |
-        if [ ${{ !contains(github.event.head_commit.message, 'skip ci') }} == true ]; then
-          echo "Installing dependencies..."
-          npm install @octokit/rest@18 --prefix ${{ github.action_path }} --no-save --loglevel error
-        fi
+        echo "Installing dependencies..."
+        npm install @octokit/rest@18 --prefix ${{ github.action_path }} --no-save --loglevel error
       shell: bash
+    - name: Get maintenance version
+      uses: BrightspaceUI/actions/get-maintenance-version@main
+      id: get-maintenance-version
     - name: Determine Increment
       id: determine-increment
       run: |
@@ -80,4 +88,15 @@ runs:
         node ${{ github.action_path }}/create-release.js ${{ steps.increment-version.outputs.version }}
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+      shell: bash
+    - name: Publish to NPM
+      if: ${{ inputs.NPM != 'false' && steps.determine-increment.outputs.increment != 'skip' }}
+      run: |
+        OPTS=""
+        [ ${{ inputs.DRY_RUN }} == true ] && OPTS=" --dry-run"
+        [ ${{ steps.get-maintenance-version.outputs.IS_MAINTENANCE_BRANCH }} == true ] && OPTS="${OPTS} --tag release-${{ steps.get-maintenance-version.outputs.MAINTENANCE_VERSION }}"
+        echo "Running npm publish with options: ${OPTS}"
+        npm publish ${OPTS}
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}
       shell: bash


### PR DESCRIPTION
This PR:

- re-adds the optional npm publish step that was originally added (then removed) by @dlockhart in PRs:
  - https://github.com/BrightspaceUI/actions/pull/75
  - https://github.com/BrightspaceUI/actions/pull/76
- adds logic for tagging any npm release coming from a "maintenance branch", to match what's now being done in `match-lms-version`:
  - https://github.com/Brightspace/lms-version-actions/pull/6
- updates `get-maintenance-version` to recognize maintenance branches that don't end with `.x`
  - e.g. `release/3.19`, which is the relevant branch that needs fixing currently

Rally: https://rally1.rallydev.com/#/?detail=/userstory/646357845471&fdp=true