### PR TITLE
Add list of dep changes to package lock updater action US145348

### DIFF
--- a/update-package-lock/action.yml
+++ b/update-package-lock/action.yml
@@ -28,6 +28,12 @@ inputs:
 runs:
   using: composite
   steps:
+      - name: Save Initial Dependencies
+        run: |
+          echo -e "\e[34mSaving Initial Dependencies"
+          npm ci
+          npm ls --json > ${{ runner.temp }}/dependencies-before.json
+        shell: bash
       - name: Install Dependencies
         run: |
           echo -e "\e[34mInstalling Dependencies"
@@ -71,6 +77,9 @@ runs:
           git add package-lock.json
           git commit -m '${{ inputs.COMMIT_MESSAGE }}'
           git push --force https://${GITHUB_TOKEN}@github.com/${{ github.repository }} ${{ inputs.BRANCH_NAME }}
+          
+          echo -e "\e[34mSaving New Dependencies"
+          npm ls --json > ${{ runner.temp }}/dependencies-after.json
         env:
           GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ inputs.NODE_AUTH_TOKEN }}
@@ -94,4 +103,5 @@ runs:
           FORCE_COLOR: 3
           GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
           PR_TITLE: ${{ inputs.PR_TITLE }}
+          TEMP_DIR: ${{ runner.temp }}
         shell: bash

--- a/update-package-lock/action.yml
+++ b/update-package-lock/action.yml
@@ -32,7 +32,7 @@ runs:
         run: |
           echo -e "\e[34mSaving Initial Dependencies"
           npm ci
-          npm ls --json > ${{ runner.temp }}/dependencies-before.json
+          npm ls --json --package-lock-only --all > ${{ runner.temp }}/dependencies-before.json
         shell: bash
       - name: Install Dependencies
         run: |
@@ -79,7 +79,7 @@ runs:
           git push --force https://${GITHUB_TOKEN}@github.com/${{ github.repository }} ${{ inputs.BRANCH_NAME }}
           
           echo -e "\e[34mSaving New Dependencies"
-          npm ls --json > ${{ runner.temp }}/dependencies-after.json
+          npm ls --json --package-lock-only --all > ${{ runner.temp }}/dependencies-after.json
         env:
           GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ inputs.NODE_AUTH_TOKEN }}

--- a/update-package-lock/action.yml
+++ b/update-package-lock/action.yml
@@ -32,7 +32,7 @@ runs:
         run: |
           echo -e "\e[34mSaving Initial Dependencies"
           npm ci
-          npm ls --json --package-lock-only --all > ${{ runner.temp }}/dependencies-before.json
+          npm ls --json --package-lock-only --all > "$RUNNER_TEMP/dependencies-before.json"
         shell: bash
       - name: Install Dependencies
         run: |
@@ -79,7 +79,7 @@ runs:
           git push --force https://${GITHUB_TOKEN}@github.com/${{ github.repository }} ${{ inputs.BRANCH_NAME }}
           
           echo -e "\e[34mSaving New Dependencies"
-          npm ls --json --package-lock-only --all > ${{ runner.temp }}/dependencies-after.json
+          npm ls --json --package-lock-only --all > "$RUNNER_TEMP/dependencies-after.json"
         env:
           GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ inputs.NODE_AUTH_TOKEN }}
@@ -103,5 +103,4 @@ runs:
           FORCE_COLOR: 3
           GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
           PR_TITLE: ${{ inputs.PR_TITLE }}
-          TEMP_DIR: ${{ runner.temp }}
         shell: bash

--- a/update-package-lock/action.yml
+++ b/update-package-lock/action.yml
@@ -49,6 +49,7 @@ runs:
       - name: Fresh Dependency Install
         run: |
           echo -e "\n\e[34mRunning Fresh Dependency Install"
+          rm -rf ./node_modules
           rm package-lock.json
           npm install
         env:

--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -74,8 +74,7 @@ const getDependencyDiff = () => {
 	}
 	
 	if (hasDiff) {
-		markDownTableDiff += `
-</details>`;
+		markDownTableDiff += `\n</details>`;
 		return markDownTableDiff;
 	}
 

--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -39,7 +39,7 @@ const flattenDependencies = (dependencies, flattenedList, flattenedKey = '') => 
 		if (rootKey === '') {
 			flattenedKey = key;
 		} else {
-			flattenedKey = rootKey + ` > ${key}`;
+			flattenedKey = `${rootKey} > ${key}`;
 		}
 
 		if (value?.version) {
@@ -62,17 +62,14 @@ const getDependencyDiff = () => {
 	flattenDependencies(afterDependencies, afterFlattenedMap);
 
 	let hasDiff = false;
-	let markDownTableDiff = `<details><summary>Dependency Changes</summary>
-| Package | Old Version | New Version |
-| --- | --- | --- |`;
+	let markDownTableDiff = `<details><summary>Dependency Changes</summary>\n| Package | Old Version | New Version |\n| --- | --- | --- |`;
 
 	for (const [key, value] of afterFlattenedMap.entries()) {
 		const oldVersion = beforeFlattenedMap.get(key);
 		const newVersion = value;
 		if (oldVersion !== newVersion) {
 			hasDiff = true;
-			markDownTableDiff+=`
-| ${key} | ${oldVersion} | ${newVersion} |`;
+			markDownTableDiff += `\n| ${key} | ${oldVersion} | ${newVersion} |`;
 		}
 	}
 	

--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -62,6 +62,7 @@ async function handlePR() {
 					associatedPullRequests(baseRefName: $base, first: 1, states: OPEN) {
 						edges {
 							node {
+								id
 								number
 							}
 						}
@@ -95,14 +96,18 @@ async function handlePR() {
 			await graphqlForPR(
 				`mutation updatePR($pullRequestId: ID!,  $body: String!) {
 					updatePullRequest(input: {pullRequestId: $pullRequestId, body: $body}) {
+						pullRequest {
+							id
+							number
+						}
 					}
 				}`,
 				{
-					pullRequestId: existingPr.node.number,
+					pullRequestId: existingPr.node.id,
 					body: prBody
 				}
 			);
-			console.log(`PR ${existingPr.node.number} body updated.`);
+			console.log(`PR ${existingPr.node.id} body updated.`);
 		} catch (e) {
 			console.log(chalk.red('Failed to update the existing PR body.'));
 			return Promise.reject(e.message);

--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -11,7 +11,7 @@ const branchName = process.env['BRANCH_NAME'];
 const defaultBranch = process.env['DEFAULT_BRANCH'];
 const prTitle = process.env['PR_TITLE'];
 const autoMergeMethod = process.env['AUTO_MERGE_METHOD'];
-const tempDir = process.env['TEMP_DIR'];
+const tempDir = process.env['RUNNER_TEMP'];
 
 const graphqlForPR = graphql.defaults({
 	headers: {

--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -95,6 +95,7 @@ async function handlePR() {
 			await graphqlForPR(
 				`mutation updatePR($pullRequestId: ID!,  $body: String!) {
 					updatePullRequest(input: {pullRequestId: $pullRequestId, body: $body}) {
+					}
 				}`,
 				{
 					pullRequestId: existingPr.node.number,

--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -28,7 +28,7 @@ const loadPackageDependencies = (filePath) => {
 		dependencies = packages?.dependencies ? packages.dependencies : {};
 	} catch {
 		return {};
-   }
+   	}
 
    return dependencies;
 };

--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -62,7 +62,9 @@ const getDependencyDiff = () => {
 	flattenDependencies(afterDependencies, afterFlattenedMap);
 
 	let hasDiff = false;
-	let markDownTableDiff = `| Package | Old Version | New Version |
+	let markDownTableDiff = `<details><summary>Dependency Changes</summary>
+<p>
+| Package | Old Version | New Version |
 | --- | --- | --- |`;
 
 	for (const [key, value] of afterFlattenedMap.entries()) {
@@ -74,8 +76,15 @@ const getDependencyDiff = () => {
 | ${key} | ${oldVersion} | ${newVersion} |`;
 		}
 	}
+	
+	if (hasDiff) {
+		markDownTableDiff += `
+</p>
+</details>`;
+		return markDownTableDiff;
+	}
 
-	return hasDiff ? markDownTableDiff : '';
+	return '';
 };
 
 async function handlePR() {

--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -63,7 +63,6 @@ const getDependencyDiff = () => {
 
 	let hasDiff = false;
 	let markDownTableDiff = `<details><summary>Dependency Changes</summary>
-<p>
 | Package | Old Version | New Version |
 | --- | --- | --- |`;
 
@@ -79,7 +78,6 @@ const getDependencyDiff = () => {
 	
 	if (hasDiff) {
 		markDownTableDiff += `
-</p>
 </details>`;
 		return markDownTableDiff;
 	}

--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -42,7 +42,7 @@ const flattenDependencies = (dependencies, flattenedList, flattenedKey = '') => 
 			flattenedKey = rootKey + ` > ${key}`;
 		}
 
-		if (value?.version && value?.resolved) {
+		if (value?.version) {
 			flattenedList.set(flattenedKey, value.version);
 		}
 


### PR DESCRIPTION
Add markdown table displaying a list of all dependency changes in the PR created by the action. See example PR of what that might look like here: https://github.com/Brightspace/d2l-rubric/pull/2322

This gives better visibility into what has changes on each update and hopefully provide useful insight into when dependency updates break things. 

![image](https://user-images.githubusercontent.com/64804046/202277247-a5b686c3-125b-4093-a876-2ce9c10a3856.png)

@svanherk @dlockhart feel free to add feedback and suggestions you have to formatting of this content in the PR body

https://rally1.rallydev.com/#/57732444928d/custom/373260458992?detail=%2Fuserstory%2F668742169561&fdp=true