### PR TITLE
Add logic to handle scenario in which a new package is added - US145348

### DIFF
--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -65,11 +65,16 @@ const getDependencyDiff = () => {
 	let markDownTableDiff = `<details><summary>Dependency Changes</summary>\n| Package | Old Version | New Version |\n| --- | --- | --- |`;
 
 	for (const [key, value] of afterFlattenedMap.entries()) {
-		const oldVersion = beforeFlattenedMap.get(key);
+		let oldVersion = beforeFlattenedMap.get(key);
 		const newVersion = value;
+		let packageName = key;
 		if (oldVersion !== newVersion) {
 			hasDiff = true;
-			markDownTableDiff += `\n| ${key} | ${oldVersion} | ${newVersion} |`;
+			if (!oldVersion) {
+				oldVersion = 'N/A';
+				packageName = `(NEW) ${packageName}`;
+			}
+			markDownTableDiff += `\n| ${packageName} | ${oldVersion} | ${newVersion} |`;
 		}
 	}
 	


### PR DESCRIPTION
Previously it looked like this: 
![image](https://user-images.githubusercontent.com/64804046/202541532-1fba2dbc-c4ac-4f98-acb1-3fb9719bb67b.png)

These changes should add `N/A` to `Old Version` and prepend package name with `(NEW)`

https://rally1.rallydev.com/#/57732444928d/custom/373260458992?detail=%2Fuserstory%2F668742169561&fdp=true