### PR TITLE
Fix incremental-release with new fine-grained PATs

### DIFF
--- a/incremental-release/action.yml
+++ b/incremental-release/action.yml
@@ -73,7 +73,7 @@ runs:
         if [ ${{ inputs.DRY_RUN }} == false ]; then
           echo "Not a dry run, pushing..."
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          git push --follow-tags --repo=https://${{ inputs.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git push --follow-tags --repo=https://x-access-token:${{ inputs.GITHUB_TOKEN }}@github.com/${{ github.repository }}
         fi
       shell: bash
     - name: Create Release


### PR DESCRIPTION
Same fix as https://github.com/Brightspace/lms-version-actions/pull/23.

My plan is to yolo this one and test it after merging by re-running https://github.com/BrightspaceHypermediaComponents/sequences/actions/runs/4128714109/jobs/7133497895.