### PR TITLE
Fix semantic-release with fine-grained PATs

### DIFF
--- a/semantic-release/action.yml
+++ b/semantic-release/action.yml
@@ -55,7 +55,7 @@ runs:
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
         git add .lmsrelease
         git commit -m "feat: updating tracked LMS release version [skip ci]"
-        git push --follow-tags --repo=https://$GITHUB_TOKEN@github.com/${{ github.repository }}
+        git push --follow-tags --repo=https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       shell: bash


### PR DESCRIPTION
Another spot we missed - we tested that `semantic-release` could handle the new fine-grained PATs, but not this LMS-branching-specific piece that only runs once a month (after branching).