### PR TITLE
US150506 - Increase semantic-release version

### DIFF
--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -51,6 +51,7 @@ Outputs:
 * `VERSION`: will contain the new version number if a release occurred, empty otherwise
 
 Notes:
+* This action currently requires `Node` version `16` or higher (or version `^14.17`).
 * If you have additional release validation steps (e.g. build step, validation tests), run them after the "Setup Node" step and before the "Semantic Release" step.
 * This example will release only from `main` and maintenance branches (e.g. `1.15.x` or `2.x`) -- see more info about maintenance branches below.
 

--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -51,7 +51,7 @@ Outputs:
 * `VERSION`: will contain the new version number if a release occurred, empty otherwise
 
 Notes:
-* This action currently requires `Node` version `16` or higher (or version `^14.17`).
+* This action currently requires Node v16+ or v14.17+ (Node v15 is not supported).
 * If you have additional release validation steps (e.g. build step, validation tests), run them after the "Setup Node" step and before the "Semantic Release" step.
 * This example will release only from `main` and maintenance branches (e.g. `1.15.x` or `2.x`) -- see more info about maintenance branches below.
 

--- a/semantic-release/action.yml
+++ b/semantic-release/action.yml
@@ -30,7 +30,7 @@ runs:
     - name: Installing semantic-release
       run: |
         echo "Installing semantic-release..."
-        npm install semantic-release@17 @semantic-release/git@9 --no-save
+        npm install semantic-release@19 @semantic-release/git@10 --no-save
       shell: bash
     - name: Get maintenance version
       uses: BrightspaceUI/actions/get-maintenance-version@main


### PR DESCRIPTION
Moving from version `17` to `19` means that everything below `Node 14.17` and `Node 15` are now unsupported. We can't move to version `20` or `21` yet because they drop support for everything under `Node 18`, which would break a large number of our repos.