### PR TITLE
US152262 - Add steps to copy goldens to .vdiff, then copy them back after tests run

### DIFF
--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -64,3 +64,69 @@ runs:
       env:
         FORCE_COLOR: 3
         PREFIX: ${{ inputs.VDIFF_BRANCH_PREFIX }}
+
+    - name: Copy Current Goldens
+      run: |
+        echo -e "\e[34mCopying Current Goldens to .vdiff"
+        echo "Clearing .vdiff directory"
+        rm -rf .vdiff
+
+        echo "Moving current goldens to .vdiff directory"
+        find . -name golden -type d | while read GOLDEN_DIR; do
+          TEST_PATH=`dirname "${GOLDEN_DIR}"`
+          TEST_PATH=${TEST_PATH:2}
+          for TEST in `ls "${GOLDEN_DIR}"`; do
+            mkdir -p "./.vdiff/${TEST_PATH}/${TEST}/golden"
+            mv "${GOLDEN_DIR}/${TEST}/"* "./.vdiff/${TEST_PATH}/${TEST}/golden"
+          done
+        done
+      env:
+        FORCE_COLOR: 3
+      shell: bash
+
+    - name: Run vdiff Tests and Upload Report
+      run: |
+        echo -e "\e[34mRunning vdiff Tests"
+        echo To Do
+      env:
+        FORCE_COLOR: 3
+      shell: bash
+
+    - name: Copy New Goldens
+      run: |
+        echo -e "\e[34mCopying New Goldens to Proper Directories"
+
+        echo "Moving passed screenshots back to golden directories"
+        find ./.vdiff -name pass -type d | while read PASS_DIR; do
+          DIR=`dirname "${PASS_DIR}"`
+          TEST_PATH=`dirname "${DIR}"`
+          TEST_PATH=${TEST_PATH:9}
+          TEST=`basename "${DIR}"`
+
+          mkdir -p "./${TEST_PATH}/golden/${TEST}"
+          mv "${PASS_DIR}/"* "./${TEST_PATH}/golden/${TEST}"    
+        done
+        
+        echo "Moving failed screenshots to golden directories"
+        find ./.vdiff -name fail -type d | while read FAIL_DIR; do
+          DIR=`dirname "${FAIL_DIR}"`
+          TEST_PATH=`dirname "${DIR}"`
+          TEST_PATH=${TEST_PATH:9}
+          TEST=`basename "${DIR}"`
+        
+          for BROWSER in `ls "${FAIL_DIR}"`; do
+            mkdir -p "./${TEST_PATH}/golden/${TEST}/${BROWSER}"
+            for PNG in `ls "${FAIL_DIR}/${BROWSER}"`; do
+              NAME=`basename "${PNG}"`
+              if  [[ ${NAME} != *"-diff.png" ]] && [[ ${NAME} != *"-resized-golden.png" ]] && [[ ${NAME} != *"-resized-screenshot.png" ]]; then
+                mv "${FAIL_DIR}/${BROWSER}/${PNG}" "./${TEST_PATH}/golden/${TEST}/${BROWSER}/${PNG}"
+              fi
+            done
+          done
+        done
+
+        echo "Clearing .vdiff directory"
+        rm -rf .vdiff
+      env:
+        FORCE_COLOR: 3
+      shell: bash

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -65,9 +65,9 @@ runs:
         FORCE_COLOR: 3
         PREFIX: ${{ inputs.VDIFF_BRANCH_PREFIX }}
 
-    - name: Copy Current Goldens
+    - name: Move Current Goldens
       run: |
-        echo -e "\e[34mCopying Current Goldens to .vdiff"
+        echo -e "\e[34mMoving Current Goldens to .vdiff"
         echo "Clearing .vdiff directory"
         rm -rf .vdiff
 
@@ -92,9 +92,9 @@ runs:
         FORCE_COLOR: 3
       shell: bash
 
-    - name: Copy New Goldens
+    - name: Move New Goldens
       run: |
-        echo -e "\e[34mCopying New Goldens to Proper Directories"
+        echo -e "\e[34mMoving New Goldens to Proper Directories"
 
         echo "Moving passed screenshots back to golden directories"
         find ./.vdiff -name pass -type d | while read PASS_DIR; do


### PR DESCRIPTION
These steps don't exist in the current action. We need to copy all the goldens from their stored locations in `golden` folders to the proper location in `.vdiff`.  Then the tests will run (added in the next PR).  Then we'll move the passed folders back as is, and copy the failed tests in.