### PR TITLE
US152262 - Add steps to run the vdiff tests, assume the AWS role and upload the report

### DIFF
--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -102,6 +102,21 @@ runs:
         FORCE_COLOR: 3
       shell: bash
 
+    - name: Prepare Report
+      id: prepare-report
+      if: ${{ inputs.AWS_ACCESS_KEY_ID }}
+      continue-on-error: true
+      run: |
+        echo -e "\e[34mPreparing vdiff Report"
+        mv "./.vdiff/.report/" "./.vdiff/report/"
+
+        DATE_TIME=$(date '+%Y-%m-%d_%H-%M-%S');
+        UPLOAD_PATH="${{ github.repository }}/${{ github.sha }}/${DATE_TIME}"
+        echo "upload-path=${UPLOAD_PATH}" >> ${GITHUB_OUTPUT}
+      env:
+        FORCE_COLOR: 3
+      shell: bash
+
     - name: Assume vdiff Role for Uploading Report
       if: ${{ inputs.AWS_ACCESS_KEY_ID }}
       continue-on-error: true
@@ -118,19 +133,11 @@ runs:
       id: upload-report
       if: ${{ inputs.AWS_ACCESS_KEY_ID }}
       continue-on-error: true
-      run: |
-        echo -e "\e[34mUpload vdiff Report"
-        mv "./.vdiff/.report/" "./.vdiff/report/"
-
-        DATE_TIME=$(date '+%Y-%m-%d_%H-%M-%S');
-        UPLOAD_PATH="${{ github.repository }}/${DATE_TIME}-${{ github.sha }}"
-        aws s3 sync --delete ./.vdiff/ s3://visual-diff.d2l.dev/reports/${UPLOAD_PATH}/
-        echo "report-path=https://vdiff.d2l.dev/${UPLOAD_PATH}/report/" >> ${GITHUB_OUTPUT}
-      env:
-        # cred variables set in the "Assume role" step
-        AWS_DEFAULT_REGION: ca-central-1
-        FORCE_COLOR: 3
-      shell: bash
+      uses: BrightspaceUI/actions/publish-to-s3@main
+      with:
+        BUCKET_PATH: s3://visual-diff.d2l.dev/reports/${{ steps.prepare-report.outputs.upload-path }}/
+        CACHE_DEFAULT: "--cache-control max-age=120"
+        PUBLISH_DIRECTORY: ./.vdiff/
 
     - name: Move New Goldens
       run: |

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -1,6 +1,15 @@
 name: vdiff
 description: Run your vdiff tests, upload a report and open a PR with the new goldens as necessary
 inputs:
+  AWS_ACCESS_KEY_ID:
+    description: Access key id for the role that will assume the vdiff role
+    required: true
+  AWS_SECRET_ACCESS_KEY:
+    description: Access key secret for the role that will assume the vdiff role
+    required: true
+  AWS_SESSION_TOKEN:
+    description: Session token for the role that will assume the vdiff role
+    required: true
   GITHUB_TOKEN:
     description: Token used to cleanup branches and open the goldens PR
     required: true
@@ -84,13 +93,45 @@ runs:
         FORCE_COLOR: 3
       shell: bash
 
-    - name: Run vdiff Tests and Upload Report
+    - name: Run vdiff Tests
+      id: test-run
       run: |
         echo -e "\e[34mRunning vdiff Tests"
-        echo To Do
+        npm run test:vdiff && echo "passed=true" >> ${GITHUB_OUTPUT} || echo "passed=false" >> ${GITHUB_OUTPUT}
       env:
         FORCE_COLOR: 3
       shell: bash
+
+    - name: Assume vdiff Role for Uploading Report
+      if: ${{ inputs.AWS_ACCESS_KEY_ID }}
+      continue-on-error: true
+      uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
+      with:
+        aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
+        aws-session-token: ${{ inputs.AWS_SESSION_TOKEN }}
+        role-to-assume: "arn:aws:iam::037018655140:role/visual-diff-githubactions-access"
+        role-duration-seconds: 3600
+        aws-region: ca-central-1
+
+    - name: Upload Report
+      id: upload-report
+      if: ${{ inputs.AWS_ACCESS_KEY_ID }}
+      continue-on-error: true
+      run: |
+        echo -e "\e[34mUpload vdiff Report"
+        mv "./.vdiff/.report/" "./.vdiff/report/"
+
+        DATE_TIME=$(date '+%Y-%m-%d_%H-%M-%S');
+        UPLOAD_PATH="${{ github.repository }}/${DATE_TIME}-${{ github.sha }}"
+        aws s3 sync --delete ./.vdiff/ s3://visual-diff.d2l.dev/reports/${UPLOAD_PATH}/
+        echo "report-path=https://vdiff.d2l.dev/${UPLOAD_PATH}/report/" >> ${GITHUB_OUTPUT}
+      env:
+        # cred variables set in the "Assume role" step
+        AWS_DEFAULT_REGION: ca-central-1
+        FORCE_COLOR: 3
+      shell: bash
+
 
     - name: Move New Goldens
       run: |

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -15,10 +15,11 @@ inputs:
     required: true
   test-chrome:
     description: Run vdiff tests in Chromium
-    default: true
+    default: false
+  test-config:
+    description: d2l-test-runner config location
   test-files:
     description: Pattern of vdiff tests to run
-    default: './test/**/*.vdiff.js'
   test-firefox:
     description: Run vdiff tests in Firefox
     default: false
@@ -27,7 +28,6 @@ inputs:
     default: false
   test-timeout:
     description: Timeout threshold for vdiff tests (in ms)
-    default: 40000
   vdiff-branch-prefix:
     description: Prefix for vdiff branches
     default: 'ghworkflow/vdiff'
@@ -126,13 +126,17 @@ runs:
       id: test-run
       run: |
         echo -e "\e[34mRunning vdiff Tests"
-        if [ ${CHROME} == true ]; then BROWSERS="--chrome "; fi
-        if [ ${FIREFOX} == true ]; then BROWSERS="${BROWSERS}--firefox "; fi
-        if [ ${SAFARI} == true ]; then BROWSERS="${BROWSERS}--safari"; fi
+        if [[ ${FILES} != "" ]]; then FLAGS="--files ${FILES} "; fi
+        if [[ ${TIMEOUT} != "" ]]; then FLAGS="${FLAGS}--timeout ${TIMEOUT} "; fi
+        if [[ ${CHROME} == "true" ]]; then FLAGS="${FLAGS}--chrome "; fi
+        if [[ ${FIREFOX} == "true" ]]; then FLAGS="${FLAGS}--firefox "; fi
+        if [[ ${SAFARI} == "true" ]]; then FLAGS="${FLAGS}--safari "; fi
+        if [[ ${CONFIG} != "" ]]; then FLAGS="${FLAGS}--config ${CONFIG}"; fi
 
-        npx d2l-test-runner vdiff --files ${FILES} --timeout ${TIMEOUT} ${BROWSERS} && echo "passed=true" >> ${GITHUB_OUTPUT} || echo "passed=false" >> ${GITHUB_OUTPUT}
+        npx d2l-test-runner vdiff ${FLAGS} && echo "passed=true" >> ${GITHUB_OUTPUT} || echo "passed=false" >> ${GITHUB_OUTPUT}
       env:
         CHROME: ${{ inputs.test-chrome }}
+        CONFIG: ${{ inputs.test-config }}
         FILES: ${{ inputs.test-files }}
         FIREFOX: ${{ inputs.test-firefox }}
         FORCE_COLOR: 3

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -1,34 +1,34 @@
 name: vdiff
 description: Run your vdiff tests, upload a report and open a PR with the new goldens as necessary
 inputs:
-  AWS_ACCESS_KEY_ID:
+  aws-access-key-id:
     description: Access key id for the role that will assume the vdiff role
     required: true
-  AWS_SECRET_ACCESS_KEY:
+  aws-secret-access-key:
     description: Access key secret for the role that will assume the vdiff role
     required: true
-  AWS_SESSION_TOKEN:
+  aws-session-token:
     description: Session token for the role that will assume the vdiff role
     required: true
-  GITHUB_TOKEN:
+  github-token:
     description: Token used to cleanup branches and open the goldens PR
     required: true
-  TEST_CHROME:
+  test-chrome:
     description: Run vdiff tests in Chromium
     default: true
-  TEST_FILES:
+  test-files:
     description: Pattern of vdiff tests to run
     default: './test/**/*.vdiff.js'
-  TEST_FIREFOX:
+  test-firefox:
     description: Run vdiff tests in Firefox
     default: false
-  TEST_SAFARI:
+  test-safari:
     description: Run vdiff tests in Webkit
     default: false
-  TEST_TIMEOUT:
+  test-timeout:
     description: Timeout threshold for vdiff tests (in ms)
     default: 40000
-  VDIFF_BRANCH_PREFIX:
+  vdiff-branch-prefix:
     description: Prefix for vdiff branches
     default: 'ghworkflow/vdiff'
 runs:
@@ -51,7 +51,7 @@ runs:
     - name: vdiff Branch Cleanup
       uses: Brightspace/third-party-actions@actions/github-script
       with:
-        github-token: ${{ inputs.GITHUB_TOKEN }}
+        github-token: ${{ inputs.github-token }}
         script: |
           console.log('\x1b[34mCleaning Up Orphaned vdiff Branches');
           const branchPrefix = `${process.env.PREFIX}-pr-`;
@@ -101,7 +101,7 @@ runs:
           console.log('Done processing vdiff branches.\n');
       env:
         FORCE_COLOR: 3
-        PREFIX: ${{ inputs.VDIFF_BRANCH_PREFIX }}
+        PREFIX: ${{ inputs.vdiff-branch-prefix }}
 
     - name: Move Current Goldens
       run: |
@@ -133,17 +133,17 @@ runs:
         echo ${BROWSERS}
         npx d2l-test-runner vdiff --files ${FILES} --timeout ${TIMEOUT} ${BROWSERS} && echo "passed=true" >> ${GITHUB_OUTPUT} || echo "passed=false" >> ${GITHUB_OUTPUT}
       env:
-        CHROME: ${{ inputs.TEST_CHROME }}
-        FILES: ${{ inputs.TEST_FILES }}
-        FIREFOX: ${{ inputs.TEST_FIREFOX }}
+        CHROME: ${{ inputs.test-chrome }}
+        FILES: ${{ inputs.test-files }}
+        FIREFOX: ${{ inputs.test-firefox }}
         FORCE_COLOR: 3
-        SAFARI: ${{ inputs.TEST_SAFARI }}
-        TIMEOUT: ${{ inputs.TEST_TIMEOUT }}
+        SAFARI: ${{ inputs.test-safari }}
+        TIMEOUT: ${{ inputs.test-timeout }}
       shell: bash
 
     - name: Prepare Report
       id: prepare-report
-      if: ${{ inputs.AWS_ACCESS_KEY_ID }}
+      if: ${{ inputs.aws-access-key-id }}
       continue-on-error: true
       run: |
         echo -e "\e[34mPreparing vdiff Report"
@@ -158,20 +158,20 @@ runs:
       shell: bash
 
     - name: Assume vdiff Role for Uploading Report
-      if: ${{ inputs.AWS_ACCESS_KEY_ID }}
+      if: ${{ inputs.aws-access-key-id }}
       continue-on-error: true
       uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
       with:
-        aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
-        aws-session-token: ${{ inputs.AWS_SESSION_TOKEN }}
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-session-token: ${{ inputs.aws-session-token }}
         role-to-assume: "arn:aws:iam::037018655140:role/visual-diff-githubactions-access"
         role-duration-seconds: 3600
         aws-region: ca-central-1
 
     - name: Upload Report
       id: upload-report
-      if: ${{ inputs.AWS_ACCESS_KEY_ID }}
+      if: ${{ inputs.aws-access-key-id }}
       continue-on-error: true
       uses: BrightspaceUI/actions/publish-to-s3@main
       with:

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -132,7 +132,6 @@ runs:
         FORCE_COLOR: 3
       shell: bash
 
-
     - name: Move New Goldens
       run: |
         echo -e "\e[34mMoving New Goldens to Proper Directories"

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -13,6 +13,21 @@ inputs:
   GITHUB_TOKEN:
     description: Token used to cleanup branches and open the goldens PR
     required: true
+  TEST_CHROME:
+    description: Run vdiff tests in Chromium
+    default: true
+  TEST_FILES:
+    description: Pattern of vdiff tests to run
+    default: './test/**/*.vdiff.js'
+  TEST_FIREFOX:
+    description: Run vdiff tests in Firefox
+    default: false
+  TEST_SAFARI:
+    description: Run vdiff tests in Webkit
+    default: false
+  TEST_TIMEOUT:
+    description: Timeout threshold for vdiff tests (in ms)
+    default: 40000
   VDIFF_BRANCH_PREFIX:
     description: Prefix for vdiff branches
     default: 'ghworkflow/vdiff'
@@ -111,9 +126,19 @@ runs:
       id: test-run
       run: |
         echo -e "\e[34mRunning vdiff Tests"
-        npm run test:vdiff && echo "passed=true" >> ${GITHUB_OUTPUT} || echo "passed=false" >> ${GITHUB_OUTPUT}
+        if [ ${CHROME} == true ]; then BROWSERS="--chrome "; fi
+        if [ ${FIREFOX} == true ]; then BROWSERS="${BROWSERS}--firefox "; fi
+        if [ ${SAFARI} == true ]; then BROWSERS="${BROWSERS}--safari"; fi
+
+        echo ${BROWSERS}
+        npx d2l-test-runner vdiff --files ${FILES} --timeout ${TIMEOUT} ${BROWSERS} && echo "passed=true" >> ${GITHUB_OUTPUT} || echo "passed=false" >> ${GITHUB_OUTPUT}
       env:
+        CHROME: ${{ inputs.TEST_CHROME }}
+        FILES: ${{ inputs.TEST_FILES }}
+        FIREFOX: ${{ inputs.TEST_FIREFOX }}
         FORCE_COLOR: 3
+        SAFARI: ${{ inputs.TEST_SAFARI }}
+        TIMEOUT: ${{ inputs.TEST_TIMEOUT }}
       shell: bash
 
     - name: Prepare Report

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -175,9 +175,9 @@ runs:
       continue-on-error: true
       uses: BrightspaceUI/actions/publish-to-s3@main
       with:
-        BUCKET_PATH: s3://visual-diff.d2l.dev/reports/${{ steps.prepare-report.outputs.upload-path }}/
-        CACHE_DEFAULT: "--cache-control max-age=120"
-        PUBLISH_DIRECTORY: ./.vdiff/
+        bucket-path: s3://visual-diff.d2l.dev/reports/${{ steps.prepare-report.outputs.upload-path }}/
+        cache-default: --cache-control max-age=120
+        publish-directory: ./.vdiff/
 
     - name: Move New Goldens
       run: |

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -19,6 +19,20 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Get Run Info
+      id: run-info
+      run: |
+        echo -e "\e[34mGetting Run Info"
+        if [ ${{ github.event.number }} ]; then
+          ORIGINAL_SHA=${{ github.event.pull_request.head.sha }}
+        else
+          ORIGINAL_SHA=${GITHUB_SHA}
+        fi
+        echo "original-sha=${ORIGINAL_SHA}" >> ${GITHUB_OUTPUT}
+      env:
+        FORCE_COLOR: 3
+      shell: bash
+
     - name: vdiff Branch Cleanup
       uses: Brightspace/third-party-actions@actions/github-script
       with:
@@ -111,10 +125,11 @@ runs:
         mv "./.vdiff/.report/" "./.vdiff/report/"
 
         DATE_TIME=$(date '+%Y-%m-%d_%H-%M-%S');
-        UPLOAD_PATH="${{ github.repository }}/${{ github.sha }}/${DATE_TIME}"
+        UPLOAD_PATH="${{ github.repository }}/${ORIGINAL_SHA}/${DATE_TIME}"
         echo "upload-path=${UPLOAD_PATH}" >> ${GITHUB_OUTPUT}
       env:
         FORCE_COLOR: 3
+        ORIGINAL_SHA: ${{ steps.run-info.outputs.original-sha }}
       shell: bash
 
     - name: Assume vdiff Role for Uploading Report

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -130,7 +130,6 @@ runs:
         if [ ${FIREFOX} == true ]; then BROWSERS="${BROWSERS}--firefox "; fi
         if [ ${SAFARI} == true ]; then BROWSERS="${BROWSERS}--safari"; fi
 
-        echo ${BROWSERS}
         npx d2l-test-runner vdiff --files ${FILES} --timeout ${TIMEOUT} ${BROWSERS} && echo "passed=true" >> ${GITHUB_OUTPUT} || echo "passed=false" >> ${GITHUB_OUTPUT}
       env:
         CHROME: ${{ inputs.test-chrome }}


### PR DESCRIPTION
The [current "run tests" step](https://github.com/BrightspaceUI/actions/blob/edfa81de66bde59d9bfd397f2bae15c2ba3f8de1/visual-diff/action.yml#L53-L66) handles running the mocha command directly, taking in each option as an input. The AWS steps are new, because previously the `visual-diff` library itself did the uploading.

Lots of questions about these pieces - will add comments inline.

Related: https://github.com/Brightspace/d2l.dev/pull/4574