### PR TITLE
US155896 - Add publish-to-s3 action from core

### DIFF
--- a/publish-to-s3/README.md
+++ b/publish-to-s3/README.md
@@ -1,0 +1,61 @@
+# Publish To S3 Action
+
+This GitHub action uses the [aws-cli](https://github.com/aws/aws-cli) (already installed on GitHub and our self-hosted runners) to upload a given directory to a given S3 bucket. The files will be compressed, and you can specify the caching you would like for these assets.
+
+## Using the Action
+
+This action could be triggered from a workflow that runs on your `main` branch after each commit or pull request merge to upload a new version to your bucket. It could also be used to upload a dev version or information for every pull request. You will need to assume the role that gives you access to the S3 bucket before running this action.
+
+Here's a sample workflow:
+
+```yml
+name: Publish
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: Brightspace/third-party-actions@actions/checkout
+      - name: Setup Node
+        uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version-file: .nvmrc
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Assume role
+        uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+          role-to-assume: <role_that_can_upload_to_your_bucket>
+          role-duration-seconds: 3600
+          aws-region: ca-central-1
+      - name: Publish
+        uses: BrightspaceUI/actions/publish-to-s3@main
+        with:
+          BUCKET_PATH: s3://<your_bucket>/<path>
+          PUBLISH_DIRECTORY: ./build/
+```
+
+Options:
+
+* `BUCKET_PATH` (required): The full path of your bucket, including subdirectories, to which to publish
+* `PUBLISH_DIRECTORY` (required): The directory within your repo to publish to S3 (e.g. `"./build/"`)
+* `CACHE` (default: `""`): An optional comma-separated list of all file extensions you wish to have cached for 1 year (e.g. `"js,css"`)
+* `CACHE_DEFAULT` (default: `""`): An optional default caching policy to apply to all files (e.g. `"--cache-control max-age=120"`)
+
+Outputs:
+* `SUCCESSFUL`: `"true"` if the publish to S3 was successful, empty otherwise
+
+## Setting Up AWS Access Creds
+
+In order to have the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` available to you for the step to assume your publishing role, you will need to configure that for your repo in repo-settings.  [See the documentation](https://github.com/Brightspace/repo-settings/blob/main/docs/aws.md).

--- a/publish-to-s3/README.md
+++ b/publish-to-s3/README.md
@@ -53,9 +53,6 @@ Options:
 * `CACHE` (default: `""`): An optional comma-separated list of all file extensions you wish to have cached for 1 year (e.g. `"js,css"`)
 * `CACHE_DEFAULT` (default: `""`): An optional default caching policy to apply to all files (e.g. `"--cache-control max-age=120"`)
 
-Outputs:
-* `SUCCESSFUL`: `"true"` if the publish to S3 was successful, empty otherwise
-
 ## Setting Up AWS Access Creds
 
 In order to have the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` available to you for the step to assume your publishing role, you will need to configure that for your repo in repo-settings.  [See the documentation](https://github.com/Brightspace/repo-settings/blob/main/docs/aws.md).

--- a/publish-to-s3/action.yml
+++ b/publish-to-s3/action.yml
@@ -1,0 +1,91 @@
+name: Publish to S3
+description: Publishes the specified directory using aws s3 sync
+
+inputs:
+  BUCKET_PATH:
+    description: The full path of your bucket, including subdirectories, to which to publish
+    required: true
+  PUBLISH_DIRECTORY:
+    description: The directory within your repo to publish to S3 (e.g. "./build/")
+    required: true
+  CACHE:
+    description: An optional comma-separated list of all file extensions you wish to have cached for 1 year (e.g. "js,css")
+    default: ""
+    required: false
+  CACHE_DEFAULT:
+    description: An optional default caching policy to apply to all files (e.g. "--cache-control max-age=120")
+    default: ""
+    required: false
+
+outputs:
+  SUCCESSFUL:
+    description: Whether the publish was successful
+    value: ${{ steps.deploy.outputs.successful }}
+
+runs:
+  using: composite
+  steps:
+    - name: Parse files
+      id: parse-files
+      run: |
+        typesToCompress=("html" "css" "js" "json" "svg" "xml")
+        typesToCache=(${CACHE//,/ })
+
+        compressAndCache=""
+        compressOnly=""
+        cacheOnly=""
+        neither=""
+
+        for type in ${typesToCompress[@]}; do
+          if [[ " ${typesToCache[*]} " =~ " ${type} " ]]; then
+            compressAndCache+="--include *.${type} "
+          else
+            compressOnly+="--include *.${type} "
+          fi
+          neither+="--exclude *.${type} "
+        done
+
+        for type in ${typesToCache[@]}; do
+          if [[ ! " ${typesToCompress[*]} " =~ " ${type} " ]]; then
+            cacheOnly+="--include *.${type} "
+            neither+="--exclude *.${type} "
+          fi
+        done
+
+        echo "COMPRESS_AND_CACHE=$compressAndCache" >> $GITHUB_OUTPUT
+        echo "COMPRESS_ONLY=$compressOnly" >> $GITHUB_OUTPUT
+        echo "CACHE_ONLY=$cacheOnly" >> $GITHUB_OUTPUT
+        echo "DEFAULT=$neither" >> $GITHUB_OUTPUT
+      env:
+        CACHE: ${{ inputs.CACHE }}
+      shell: bash
+
+    - name: Compress
+      run: find $PUBLISH_DIRECTORY \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.json' -o -iname '*.svg' -o -iname '*.xml' \) -exec brotli {} \; -exec mv {}.br {} \;
+      env:
+        PUBLISH_DIRECTORY: ${{ inputs.PUBLISH_DIRECTORY }}
+      shell: bash
+
+    - name: Deploy
+      id: deploy
+      run: |
+        # Disable globbing: We want arguments like '*.js' to be treated as string literals, without needing quotes
+        # (Passing quotes in strings does not work as expected during shell expansion)
+        set -f
+
+        [[ $FILES_COMPRESS_AND_CACHE ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_POLICY --exclude *.* $FILES_COMPRESS_AND_CACHE
+        [[ $FILES_COMPRESS_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_DEFAULT --exclude *.* $FILES_COMPRESS_ONLY
+        [[ $FILES_CACHE_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_POLICY --exclude *.* $FILES_CACHE_ONLY
+        aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_DEFAULT $FILES_DEFAULT
+        echo "successful=true" >> $GITHUB_OUTPUT
+      env:
+        BUCKET_PATH: ${{ inputs.BUCKET_PATH }}
+        PUBLISH_DIRECTORY: ${{ inputs.PUBLISH_DIRECTORY }}
+        CACHE_POLICY: --cache-control public,max-age=31536000,immutable
+        CACHE_DEFAULT: ${{ inputs.CACHE_DEFAULT }}
+        COMPRESS_ENCODING: --content-encoding br
+        FILES_CACHE_ONLY: ${{ steps.parse-files.outputs.CACHE_ONLY }}
+        FILES_COMPRESS_AND_CACHE: ${{ steps.parse-files.outputs.COMPRESS_AND_CACHE }}
+        FILES_COMPRESS_ONLY: ${{ steps.parse-files.outputs.COMPRESS_ONLY }}
+        FILES_DEFAULT: ${{ steps.parse-files.outputs.DEFAULT }}
+      shell: bash

--- a/publish-to-s3/action.yml
+++ b/publish-to-s3/action.yml
@@ -17,11 +17,6 @@ inputs:
     default: ""
     required: false
 
-outputs:
-  SUCCESSFUL:
-    description: Whether the publish was successful
-    value: ${{ steps.deploy.outputs.successful }}
-
 runs:
   using: composite
   steps:
@@ -67,7 +62,6 @@ runs:
       shell: bash
 
     - name: Deploy
-      id: deploy
       run: |
         # Disable globbing: We want arguments like '*.js' to be treated as string literals, without needing quotes
         # (Passing quotes in strings does not work as expected during shell expansion)
@@ -77,7 +71,6 @@ runs:
         [[ $FILES_COMPRESS_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_DEFAULT --exclude *.* $FILES_COMPRESS_ONLY
         [[ $FILES_CACHE_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_POLICY --exclude *.* $FILES_CACHE_ONLY
         aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_DEFAULT $FILES_DEFAULT
-        echo "successful=true" >> $GITHUB_OUTPUT
       env:
         BUCKET_PATH: ${{ inputs.BUCKET_PATH }}
         PUBLISH_DIRECTORY: ${{ inputs.PUBLISH_DIRECTORY }}


### PR DESCRIPTION
This is [lifted from `core`](https://github.com/BrightspaceUI/core/blob/03dfe28bf436cf26e329c38066dee2e1b692e594/.github/actions/publish-to-s3/action.yml#L1). The only changes I made were moving the `env` variables after `run` to match the layout of all the other actions in this repo, and adding the `README`. 

Originally I had an output for whether the publish was successful or not, but I think I can get that using a mix of `continue-on-error` and `failure()`.  If not I'll add it back here.

I'll put up a PR in `core` to switch to this, and update the `vdiff` PR to use it.