### PR TITLE
Switch publish-to-s3 to lowercase inputs and outputs

### DIFF
--- a/publish-to-s3/README.md
+++ b/publish-to-s3/README.md
@@ -42,17 +42,17 @@ jobs:
       - name: Publish
         uses: BrightspaceUI/actions/publish-to-s3@main
         with:
-          BUCKET_PATH: s3://<your_bucket>/<path>
-          PUBLISH_DIRECTORY: ./build/
+          bucket-path: s3://<your_bucket>/<path>
+          publish-directory: ./build/
 ```
 
 Options:
 
-* `BUCKET_PATH` (required): The full path of your bucket, including subdirectories, to which to publish
-* `PUBLISH_DIRECTORY` (required): The directory within your repo to publish to S3 (e.g. `"./build/"`)
-* `CACHE` (default: `""`): An optional comma-separated list of all file extensions you wish to have cached for 1 year (e.g. `"js,css"`)
-* `CACHE_DEFAULT` (default: `""`): An optional default caching policy to apply to all files (e.g. `"--cache-control max-age=120"`)
+* `bucket-path` (required): The full path of your bucket, including subdirectories, to which to publish
+* `publish-directory` (required): The directory within your repo to publish to S3 (e.g. `"./build/"`)
+* `cache` (default: `""`): An optional comma-separated list of all file extensions you wish to have cached for 1 year (e.g. `"js,css"`)
+* `cache-default` (default: `""`): An optional default caching policy to apply to all files (e.g. `"--cache-control max-age=120"`)
 
 ## Setting Up AWS Access Creds
 
-In order to have the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` available to you for the step to assume your publishing role, you will need to configure that for your repo in repo-settings.  [See the documentation](https://github.com/Brightspace/repo-settings/blob/main/docs/aws.md).
+In order to have the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` secrets available to you for the step to assume your publishing role, you will need to configure that for your repo in `repo-settings`.  [See the documentation](https://github.com/Brightspace/repo-settings/blob/main/docs/aws.md).

--- a/publish-to-s3/action.yml
+++ b/publish-to-s3/action.yml
@@ -2,17 +2,17 @@ name: Publish to S3
 description: Publishes the specified directory using aws s3 sync
 
 inputs:
-  BUCKET_PATH:
+  bucket-path:
     description: The full path of your bucket, including subdirectories, to which to publish
     required: true
-  PUBLISH_DIRECTORY:
+  publish-directory:
     description: The directory within your repo to publish to S3 (e.g. "./build/")
     required: true
-  CACHE:
+  cache:
     description: An optional comma-separated list of all file extensions you wish to have cached for 1 year (e.g. "js,css")
     default: ""
     required: false
-  CACHE_DEFAULT:
+  cache-default:
     description: An optional default caching policy to apply to all files (e.g. "--cache-control max-age=120")
     default: ""
     required: false
@@ -47,18 +47,18 @@ runs:
           fi
         done
 
-        echo "COMPRESS_AND_CACHE=$compressAndCache" >> $GITHUB_OUTPUT
-        echo "COMPRESS_ONLY=$compressOnly" >> $GITHUB_OUTPUT
-        echo "CACHE_ONLY=$cacheOnly" >> $GITHUB_OUTPUT
-        echo "DEFAULT=$neither" >> $GITHUB_OUTPUT
+        echo "compress-and-cache=$compressAndCache" >> $GITHUB_OUTPUT
+        echo "compress-only=$compressOnly" >> $GITHUB_OUTPUT
+        echo "cache-only=$cacheOnly" >> $GITHUB_OUTPUT
+        echo "default=$neither" >> $GITHUB_OUTPUT
       env:
-        CACHE: ${{ inputs.CACHE }}
+        CACHE: ${{ inputs.cache }}
       shell: bash
 
     - name: Compress
       run: find $PUBLISH_DIRECTORY \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.json' -o -iname '*.svg' -o -iname '*.xml' \) -exec brotli {} \; -exec mv {}.br {} \;
       env:
-        PUBLISH_DIRECTORY: ${{ inputs.PUBLISH_DIRECTORY }}
+        PUBLISH_DIRECTORY: ${{ inputs.publish-directory }}
       shell: bash
 
     - name: Deploy
@@ -72,13 +72,13 @@ runs:
         [[ $FILES_CACHE_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_POLICY --exclude *.* $FILES_CACHE_ONLY
         aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_DEFAULT $FILES_DEFAULT
       env:
-        BUCKET_PATH: ${{ inputs.BUCKET_PATH }}
-        PUBLISH_DIRECTORY: ${{ inputs.PUBLISH_DIRECTORY }}
+        BUCKET_PATH: ${{ inputs.bucket-path }}
+        PUBLISH_DIRECTORY: ${{ inputs.publish-directory }}
         CACHE_POLICY: --cache-control public,max-age=31536000,immutable
-        CACHE_DEFAULT: ${{ inputs.CACHE_DEFAULT }}
+        CACHE_DEFAULT: ${{ inputs.cache-default }}
         COMPRESS_ENCODING: --content-encoding br
-        FILES_CACHE_ONLY: ${{ steps.parse-files.outputs.CACHE_ONLY }}
-        FILES_COMPRESS_AND_CACHE: ${{ steps.parse-files.outputs.COMPRESS_AND_CACHE }}
-        FILES_COMPRESS_ONLY: ${{ steps.parse-files.outputs.COMPRESS_ONLY }}
-        FILES_DEFAULT: ${{ steps.parse-files.outputs.DEFAULT }}
+        FILES_CACHE_ONLY: ${{ steps.parse-files.outputs.cache-only }}
+        FILES_COMPRESS_AND_CACHE: ${{ steps.parse-files.outputs.compress-and-cache }}
+        FILES_COMPRESS_ONLY: ${{ steps.parse-files.outputs.compress-only }}
+        FILES_DEFAULT: ${{ steps.parse-files.outputs.default }}
       shell: bash


### PR DESCRIPTION
We'd like to start using lowercase inputs and outputs. Since only `core` is using this so far, it's easy to switch this one.