### PR TITLE
feat: Add comment-on-pr action from core

### DIFF
--- a/comment-on-pr/README.md
+++ b/comment-on-pr/README.md
@@ -1,0 +1,35 @@
+# Comment On PR Action
+
+This GitHub action uses the [GitHub REST API](https://octokit.github.io/rest.js/v19#issues-create-comment) to add a comment to the current PR as the `github-actions` user, with an option to only post once per PR.
+
+## Using the Action
+
+This action **can only be used on `pull_request` event types**, since it posts to the PR that triggers the action. It can be used to write any comment, and can be combined with other steps in your workflow to convey information from your CI process.
+
+In situations where you only want to post once on a given PR, use `only-post-once: true`. Every comment from this action includes a hidden key in an HTML comment, which is used by `only-post-once` to detect if a post has already been created. Use `unique-key` to specify your own unique key, which can be useful e.g. if you want to uniquely post two different comments.
+
+Here's a sample workflow:
+
+```yml
+name: Comment
+on: pull_request
+jobs:
+  comment:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on PR
+        uses: BrightspaceUI/actions/comment-on-pr@main
+        with:
+          MESSAGE: |
+            Thanks for the PR! 🎉
+
+            This is a sample multiline comment.
+          ONLY_POST_ONCE: true
+```
+
+Options:
+
+* `message` (required): The message to display
+* `only-post-once` (default: `false`): Check whether the current message has already been posted before posting again
+* `unique-key` (default: `"gh-actions_comment-on-pr"`): A unique key attached invisibly to the comment, for use with the `only-post-once` option

--- a/comment-on-pr/README.md
+++ b/comment-on-pr/README.md
@@ -21,11 +21,11 @@ jobs:
       - name: Comment on PR
         uses: BrightspaceUI/actions/comment-on-pr@main
         with:
-          MESSAGE: |
+          message: |
             Thanks for the PR! 🎉
 
             This is a sample multiline comment.
-          ONLY_POST_ONCE: true
+          only-post-once: true
 ```
 
 Options:

--- a/comment-on-pr/action.yml
+++ b/comment-on-pr/action.yml
@@ -2,35 +2,35 @@ name: Comment on PR
 description: Adds a comment on the current PR
 
 inputs:
-  MESSAGE:
+  message:
     description: The message to display
     required: true
-  ONLY_POST_ONCE:
+  only-post-once:
     description: Check whether the current message has already been posted before posting again
     default: false
     required: false
-  UNIQUE_KEY:
-    description: A unique key attached invisibly to the comment, for use with the ONLY_POST_ONCE option
-    default: gh-actions--comment-on-pr
+  unique-key:
+    description: A unique key attached invisibly to the comment, for use with the `only-post-once` option
+    default: gh-actions_comment-on-pr
     required: false
 
 runs:
   using: composite
   steps:
-    - name: Find Previous Comment
-      if: ${{ inputs.ONLY_POST_ONCE != 'false' }}
+    - name: Find previous comment
+      if: ${{ inputs.only-post-once != 'false' }}
       uses: Brightspace/third-party-actions@peter-evans/find-comment
       id: fc
       with:
         issue-number: ${{ github.event.pull_request.number }}
-        body-includes: ${{ inputs.UNIQUE_KEY }}
+        body-includes: ${{ inputs.unique-key }}
 
-    - name: PR Deployment URLs
-      if: ${{ inputs.ONLY_POST_ONCE == 'false' || steps.fc.outputs.comment-id == '' }}
+    - name: Create PR comment
+      if: ${{ inputs.only-post-once == 'false' || steps.fc.outputs.comment-id == '' }}
       uses: Brightspace/third-party-actions@actions/github-script
       env:
-        MESSAGE: ${{ inputs.MESSAGE }}
-        UNIQUE_KEY: ${{ inputs.UNIQUE_KEY }}
+        MESSAGE: ${{ inputs.message }}
+        UNIQUE_KEY: ${{ inputs.unique-key }}
       with:
         script: |
           github.rest.issues.createComment({

--- a/comment-on-pr/action.yml
+++ b/comment-on-pr/action.yml
@@ -1,0 +1,41 @@
+name: Comment on PR
+description: Adds a comment on the current PR
+
+inputs:
+  MESSAGE:
+    description: The message to display
+    required: true
+  ONLY_POST_ONCE:
+    description: Check whether the current message has already been posted before posting again
+    default: false
+    required: false
+  UNIQUE_KEY:
+    description: A unique key attached invisibly to the comment, for use with the ONLY_POST_ONCE option
+    default: gh-actions--comment-on-pr
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Find Previous Comment
+      if: ${{ inputs.ONLY_POST_ONCE != 'false' }}
+      uses: Brightspace/third-party-actions@peter-evans/find-comment
+      id: fc
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body-includes: ${{ inputs.UNIQUE_KEY }}
+
+    - name: PR Deployment URLs
+      if: ${{ inputs.ONLY_POST_ONCE == 'false' || steps.fc.outputs.comment-id == '' }}
+      uses: Brightspace/third-party-actions@actions/github-script
+      env:
+        MESSAGE: ${{ inputs.MESSAGE }}
+        UNIQUE_KEY: ${{ inputs.UNIQUE_KEY }}
+      with:
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `<!-- ${process.env.UNIQUE_KEY} -->\n\n${process.env.MESSAGE}`
+          })


### PR DESCRIPTION
I'm working on making "PR Previews" into a more reusable pattern that all teams can easily implement. Part of that is moving the required actions out of core to somewhere more central.

This PR:

- [copies `comment-on-pr` from core](https://github.com/BrightspaceUI/core/blob/main/.github/actions/comment-on-pr/action.yml)
- updates inputs/outputs to lowercase
- adds a readme

I'll make a follow-up PR to core once this is merged, to use the shared action.

[US156216](https://rally1.rallydev.com/#/?detail=/userstory/719304972319&fdp=true)
