### PR TITLE
US152262 - Add option to only log errors to publish-to-s3

### DIFF
--- a/publish-to-s3/README.md
+++ b/publish-to-s3/README.md
@@ -52,6 +52,7 @@ Options:
 * `publish-directory` (required): The directory within your repo to publish to S3 (e.g. `"./build/"`)
 * `cache` (default: `""`): An optional comma-separated list of all file extensions you wish to have cached for 1 year (e.g. `"js,css"`)
 * `cache-default` (default: `""`): An optional default caching policy to apply to all files (e.g. `"--cache-control max-age=120"`)
+* `only-log-errors` (default: false): Only log the errors from aws s3 sync
 
 ## Setting Up AWS Access Creds
 

--- a/publish-to-s3/action.yml
+++ b/publish-to-s3/action.yml
@@ -16,6 +16,9 @@ inputs:
     description: An optional default caching policy to apply to all files (e.g. "--cache-control max-age=120")
     default: ""
     required: false
+  only-log-errors:
+    description: Only log the errors from aws s3 sync
+    default: false
 
 runs:
   using: composite
@@ -67,10 +70,14 @@ runs:
         # (Passing quotes in strings does not work as expected during shell expansion)
         set -f
 
-        [[ $FILES_COMPRESS_AND_CACHE ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_POLICY --exclude *.* $FILES_COMPRESS_AND_CACHE
-        [[ $FILES_COMPRESS_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_DEFAULT --exclude *.* $FILES_COMPRESS_ONLY
-        [[ $FILES_CACHE_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_POLICY --exclude *.* $FILES_CACHE_ONLY
-        aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_DEFAULT $FILES_DEFAULT
+        if [[ ${ONLY_LOG_ERRORS} == "true" ]]; then LOG_LEVEL="--only-show-errors "; fi
+
+        [[ $FILES_COMPRESS_AND_CACHE ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_POLICY --exclude *.* $FILES_COMPRESS_AND_CACHE $LOG_LEVEL
+        [[ $FILES_COMPRESS_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_DEFAULT --exclude *.* $FILES_COMPRESS_ONLY $LOG_LEVEL
+        [[ $FILES_CACHE_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_POLICY --exclude *.* $FILES_CACHE_ONLY $LOG_LEVEL
+        aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_DEFAULT $FILES_DEFAULT $LOG_LEVEL
+
+        echo -e "\e[32mPublish complete\n"
       env:
         BUCKET_PATH: ${{ inputs.bucket-path }}
         PUBLISH_DIRECTORY: ${{ inputs.publish-directory }}
@@ -81,4 +88,5 @@ runs:
         FILES_COMPRESS_AND_CACHE: ${{ steps.parse-files.outputs.compress-and-cache }}
         FILES_COMPRESS_ONLY: ${{ steps.parse-files.outputs.compress-only }}
         FILES_DEFAULT: ${{ steps.parse-files.outputs.default }}
+        ONLY_LOG_ERRORS: ${{ inputs.only-log-errors }}
       shell: bash

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -210,6 +210,7 @@ runs:
         bucket-path: s3://visual-diff.d2l.dev/reports/${{ steps.prepare-report.outputs.upload-path }}/
         cache-default: --cache-control max-age=120
         publish-directory: ./.vdiff/
+        only-log-errors: true
 
     - name: Move New Goldens
       run: |


### PR DESCRIPTION
The S3 sync command is pretty noisy, especially with compression. Publishing the report is only a small piece of `vdiff` and we don't really need to care about each file uploaded.
This PR:
- Adds an option to only log the errors from AWS S3 sync commands in the `publish-to-s3` action
- Use it in the `vdiff` action