### PR TITLE
vdiff: Ignore old visual-diff folders 

### DIFF
--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -142,6 +142,9 @@ runs:
         find . -name golden -type d | while read GOLDEN_DIR; do
           TEST_PATH=`dirname "${GOLDEN_DIR}"`
           TEST_PATH=${TEST_PATH:2}
+
+          if [[ ${TEST_PATH} == *screenshots/ci ]]; then continue; fi
+
           for TEST in `ls "${GOLDEN_DIR}"`; do
             mkdir -p "./.vdiff/${TEST_PATH}/${TEST}/golden"
             mv "${GOLDEN_DIR}/${TEST}/"* "./.vdiff/${TEST_PATH}/${TEST}/golden"


### PR DESCRIPTION
Didn't take very long for [this ](https://github.com/BrightspaceUI/actions/pull/114#discussion_r1274074894)to bite me. We want to ignore the old `visual-diff`'s `/screenshots/ci/golden` folders to allow for both versions of `vdiff` to exist in the same repo.  That way we can slowly migrate tests over.

We could remove this once everyone is migrated, to force cleanup of any remaining folders, but 🤷 