### PR TITLE
Add note about favouring semantic-release

### DIFF
--- a/incremental-release/README.md
+++ b/incremental-release/README.md
@@ -2,6 +2,8 @@
 
 This GitHub action looks for keywords in the latest commit to automatically increment the package version, create a GitHub release/tag, and optionally publish to NPM.
 
+> ⚠️ Where possible, use the [`semantic-release`](../semantic-release) instead! It offers similar functionality with a more standard versioning syntax.
+
 ## Using the Action
 
 Typically this action is triggered from a workflow that runs on your `main` branch after each commit or pull request merge.


### PR DESCRIPTION
I believe we've talked about phasing out this action in favour of `semantic-release`... correct me if I'm wrong! 😄 

This is also mentioned in [How to publish a repo to npm or CodeArtifact](https://desire2learn.atlassian.net/wiki/spaces/DEVCENTRAL/pages/3609003416/How+to+publish+a+repo+to+npm+or+CodeArtifact).