### PR TITLE
Add support for setting files to public-read when syncing to S3

### DIFF
--- a/publish-to-s3/README.md
+++ b/publish-to-s3/README.md
@@ -53,6 +53,7 @@ Options:
 * `cache` (default: `""`): An optional comma-separated list of all file extensions you wish to have cached for 1 year (e.g. `"js,css"`)
 * `cache-default` (default: `""`): An optional default caching policy to apply to all files (e.g. `"--cache-control max-age=120"`)
 * `only-log-errors` (default: false): Only log the errors from aws s3 sync
+* `public-read` (default: false) Sets access permissions on all files to public-read
 
 ## Setting Up AWS Access Creds
 

--- a/publish-to-s3/README.md
+++ b/publish-to-s3/README.md
@@ -53,7 +53,7 @@ Options:
 * `cache` (default: `""`): An optional comma-separated list of all file extensions you wish to have cached for 1 year (e.g. `"js,css"`)
 * `cache-default` (default: `""`): An optional default caching policy to apply to all files (e.g. `"--cache-control max-age=120"`)
 * `only-log-errors` (default: false): Only log the errors from aws s3 sync
-* `public-read` (default: false) Sets access permissions on all files to public-read
+* `public-read` (default: false): Sets access permissions on all files to public-read
 
 ## Setting Up AWS Access Creds
 

--- a/publish-to-s3/action.yml
+++ b/publish-to-s3/action.yml
@@ -74,7 +74,7 @@ runs:
         set -f
 
         if [[ ${ONLY_LOG_ERRORS} == "true" ]]; then LOG_LEVEL="--only-show-errors "; fi
-        if [[ ${PUBLIC_READ} == "true" ]]; then ACCESS_PERMISSIONS="--acl public-read ";fi
+        if [[ ${PUBLIC_READ} == "true" ]]; then ACCESS_PERMISSIONS="--acl public-read "; fi
 
         [[ $FILES_COMPRESS_AND_CACHE ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_POLICY --exclude *.* $FILES_COMPRESS_AND_CACHE $LOG_LEVEL $ACCESS_PERMISSIONS
         [[ $FILES_COMPRESS_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_DEFAULT --exclude *.* $FILES_COMPRESS_ONLY $LOG_LEVEL $ACCESS_PERMISSIONS

--- a/publish-to-s3/action.yml
+++ b/publish-to-s3/action.yml
@@ -19,6 +19,9 @@ inputs:
   only-log-errors:
     description: Only log the errors from aws s3 sync
     default: false
+  public-read:
+    description: Sets the access permissions for all files to public-read
+    default: false
 
 runs:
   using: composite
@@ -71,11 +74,12 @@ runs:
         set -f
 
         if [[ ${ONLY_LOG_ERRORS} == "true" ]]; then LOG_LEVEL="--only-show-errors "; fi
+        if [[ ${PUBLIC_READ} == "true" ]]; then ACCESS_PERMISSIONS="--acl public-read ";fi
 
-        [[ $FILES_COMPRESS_AND_CACHE ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_POLICY --exclude *.* $FILES_COMPRESS_AND_CACHE $LOG_LEVEL
-        [[ $FILES_COMPRESS_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_DEFAULT --exclude *.* $FILES_COMPRESS_ONLY $LOG_LEVEL
-        [[ $FILES_CACHE_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_POLICY --exclude *.* $FILES_CACHE_ONLY $LOG_LEVEL
-        aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_DEFAULT $FILES_DEFAULT $LOG_LEVEL
+        [[ $FILES_COMPRESS_AND_CACHE ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_POLICY --exclude *.* $FILES_COMPRESS_AND_CACHE $LOG_LEVEL $ACCESS_PERMISSIONS
+        [[ $FILES_COMPRESS_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_DEFAULT --exclude *.* $FILES_COMPRESS_ONLY $LOG_LEVEL $ACCESS_PERMISSIONS
+        [[ $FILES_CACHE_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_POLICY --exclude *.* $FILES_CACHE_ONLY $LOG_LEVEL $ACCESS_PERMISSIONS
+        aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_DEFAULT $FILES_DEFAULT $LOG_LEVEL $ACCESS_PERMISSIONS
 
         echo -e "\e[32mPublish complete\n"
       env:
@@ -89,4 +93,5 @@ runs:
         FILES_COMPRESS_ONLY: ${{ steps.parse-files.outputs.compress-only }}
         FILES_DEFAULT: ${{ steps.parse-files.outputs.default }}
         ONLY_LOG_ERRORS: ${{ inputs.only-log-errors }}
+        PUBLIC_READ: ${{ inputs.public-read }}
       shell: bash


### PR DESCRIPTION
Giving a shot at adding support for `--acl public-read` to the `publish-to-s3` action so it can be used to publish files to the CDN. This is a bit out of my wheelhouse so hopefully this isn't crazy broken. 😅 