### PR TITLE
Grab job display name instead of id

### DIFF
--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -58,24 +58,52 @@ runs:
         PREFIX: ${{ inputs.vdiff-branch-prefix }}
       shell: bash
 
+    - name: Get Job Name
+      id: job-name
+      uses: Brightspace/third-party-actions@actions/github-script
+      with:
+        github-token: ${{ inputs.github-token }}
+        result-encoding: string
+        script: |
+          console.log('\x1b[34mGetting Job Name');
+
+          const { data: { jobs } = {} } = await github.rest.actions.listJobsForWorkflowRunAttempt({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: context.runId,
+            attempt_number: process.env.GITHUB_RUN_ATTEMPT
+          });
+          const runnerName = process.env.RUNNER_NAME;
+          const jobNames = jobs
+            .filter(({runner_name}) => runner_name === runnerName)
+            .map(({name}) => name);
+
+          return jobNames.length === 1 ? jobNames[0] : context.job;
+      env:
+        FORCE_COLOR: 3
+
     - name: Create Commit Status
       uses: Brightspace/third-party-actions@actions/github-script
       with:
         github-token: ${{ inputs.github-token }}
         script: |
           console.log('\x1b[34mCreating Pending Commit Status');
-          
+
+          const jobName = process.env.JOB_NAME;
+          const resultsText = jobName[0].toUpperCase() === jobName[0] ? 'Results' : 'results'
+
           await github.rest.repos.createCommitStatus({
             owner: context.repo.owner,
             repo: context.repo.repo,
             sha: process.env.ORIGINAL_SHA,
             state: 'pending',
             description: 'Run in progress',
-            context: `${context.workflow} / ${context.job} results (${context.eventName})`
+            context: `${context.workflow} / ${jobName} ${resultsText} (${context.eventName})`
           });
       env:
         FORCE_COLOR: 3
         ORIGINAL_SHA: ${{ steps.run-info.outputs.original-sha }}
+        JOB_NAME: ${{ steps.job-name.outputs.result }}
 
     - name: vdiff Branch Cleanup
       uses: Brightspace/third-party-actions@actions/github-script
@@ -103,7 +131,7 @@ runs:
                 repo: context.repo.repo,
                 pull_number: prNum
               });
-        
+
               if (prInfo.data.state !== 'open') {
                 prOpen = false;
               }
@@ -227,16 +255,16 @@ runs:
           TEST=`basename "${DIR}"`
 
           mkdir -p "./${TEST_PATH}/golden/${TEST}"
-          mv "${PASS_DIR}/"* "./${TEST_PATH}/golden/${TEST}"    
+          mv "${PASS_DIR}/"* "./${TEST_PATH}/golden/${TEST}"
         done
-        
+
         echo "Moving failed screenshots to golden directories"
         find ./.vdiff -name fail -type d | while read FAIL_DIR; do
           DIR=`dirname "${FAIL_DIR}"`
           TEST_PATH=`dirname "${DIR}"`
           TEST_PATH=${TEST_PATH:9}
           TEST=`basename "${DIR}"`
-        
+
           for BROWSER in `ls "${FAIL_DIR}"`; do
             mkdir -p "./${TEST_PATH}/golden/${TEST}/${BROWSER}"
             for PNG in `ls "${FAIL_DIR}/${BROWSER}"`; do
@@ -483,6 +511,9 @@ runs:
             core.setFailed('Completed - Build Failed.');
           }
 
+          const jobName = process.env.JOB_NAME;
+          const resultsText = jobName[0].toUpperCase() === jobName[0] ? 'Results' : 'results'
+
           await github.rest.repos.createCommitStatus({
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -490,7 +521,7 @@ runs:
             state: state,
             target_url: targetUrl,
             description: description,
-            context: `${context.workflow} / ${context.job} results (${context.eventName})`
+            context: `${context.workflow} / ${jobName} ${resultsText} (${context.eventName})`
           });
       env:
         FORCE_COLOR: 3
@@ -499,3 +530,4 @@ runs:
         ORIGINAL_SHA: ${{ steps.run-info.outputs.original-sha }}
         PULL_REQUEST_NUM: ${{ steps.pull-request.outputs.num }}
         TESTS_PASSED: ${{ steps.test-run.outputs.passed }}
+        JOB_NAME: ${{ steps.job-name.outputs.result }}

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -58,14 +58,14 @@ runs:
         PREFIX: ${{ inputs.vdiff-branch-prefix }}
       shell: bash
 
-    - name: Get Job Name
-      id: job-name
+    - name: Generate Commit Status Name
+      id: commit-status-name
       uses: Brightspace/third-party-actions@actions/github-script
       with:
         github-token: ${{ inputs.github-token }}
         result-encoding: string
         script: |
-          console.log('\x1b[34mGetting Job Name');
+          console.log('\x1b[34mGenerating Commit Status Name');
 
           const { data: { jobs } = {} } = await github.rest.actions.listJobsForWorkflowRunAttempt({
             owner: context.repo.owner,
@@ -77,8 +77,10 @@ runs:
           const jobNames = jobs
             .filter(({runner_name}) => runner_name === runnerName)
             .map(({name}) => name);
+          const jobName = jobNames.length === 1 ? jobNames[0] : context.job;
+          const resultsText = jobName[0].toUpperCase() === jobName[0] ? 'Results' : 'results';
 
-          return jobNames.length === 1 ? jobNames[0] : context.job;
+          return `${context.workflow} / ${jobName} ${resultsText} (${context.eventName})`;
       env:
         FORCE_COLOR: 3
 
@@ -89,21 +91,18 @@ runs:
         script: |
           console.log('\x1b[34mCreating Pending Commit Status');
 
-          const jobName = process.env.JOB_NAME;
-          const resultsText = jobName[0].toUpperCase() === jobName[0] ? 'Results' : 'results'
-
           await github.rest.repos.createCommitStatus({
             owner: context.repo.owner,
             repo: context.repo.repo,
             sha: process.env.ORIGINAL_SHA,
             state: 'pending',
             description: 'Run in progress',
-            context: `${context.workflow} / ${jobName} ${resultsText} (${context.eventName})`
+            context: process.env.COMMIT_STATUS_NAME
           });
       env:
         FORCE_COLOR: 3
         ORIGINAL_SHA: ${{ steps.run-info.outputs.original-sha }}
-        JOB_NAME: ${{ steps.job-name.outputs.result }}
+        COMMIT_STATUS_NAME: ${{ steps.commit-status-name.outputs.result }}
 
     - name: vdiff Branch Cleanup
       uses: Brightspace/third-party-actions@actions/github-script
@@ -511,9 +510,6 @@ runs:
             core.setFailed('Completed - Build Failed.');
           }
 
-          const jobName = process.env.JOB_NAME;
-          const resultsText = jobName[0].toUpperCase() === jobName[0] ? 'Results' : 'results'
-
           await github.rest.repos.createCommitStatus({
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -521,7 +517,7 @@ runs:
             state: state,
             target_url: targetUrl,
             description: description,
-            context: `${context.workflow} / ${jobName} ${resultsText} (${context.eventName})`
+            context: process.env.COMMIT_STATUS_NAME
           });
       env:
         FORCE_COLOR: 3
@@ -530,4 +526,4 @@ runs:
         ORIGINAL_SHA: ${{ steps.run-info.outputs.original-sha }}
         PULL_REQUEST_NUM: ${{ steps.pull-request.outputs.num }}
         TESTS_PASSED: ${{ steps.test-run.outputs.passed }}
-        JOB_NAME: ${{ steps.job-name.outputs.result }}
+        COMMIT_STATUS_NAME: ${{ steps.commit-status-name.outputs.result }}


### PR DESCRIPTION
This uses a round about way to get the actual job display name for the vdiff check status. Right now it uses the `job_id` string value as defined in the [workflow file](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_id) not the actual display name. See [below comment](https://github.com/BrightspaceUI/actions/pull/131#discussion_r1340567593) for more details.

Tested with https://github.com/BrightspaceUI/core/pull/4145 and https://github.com/Brightspace/d2l-outcomes/pull/812.