### PR TITLE
Don't try to upload broken vdiff report

### DIFF
--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -224,7 +224,7 @@ runs:
       shell: bash
 
     - name: Assume vdiff Role for Uploading Report
-      if: ${{ inputs.aws-access-key-id }}
+      if: ${{ inputs.aws-access-key-id && steps.prepare-report.outputs.upload-path }}
       continue-on-error: true
       uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
       with:
@@ -237,7 +237,7 @@ runs:
 
     - name: Upload Report
       id: upload-report
-      if: ${{ inputs.aws-access-key-id }}
+      if: ${{ inputs.aws-access-key-id && steps.prepare-report.outputs.upload-path }}
       continue-on-error: true
       uses: BrightspaceUI/actions/publish-to-s3@main
       with:


### PR DESCRIPTION
If we didn't get a valid upload-path, we can't do the upload anyways. This can happen when the tests fail to run for some reason ([example](https://github.com/BrightspaceUI/labs/actions/runs/6732673907/job/18299817635?pr=182)).