### PR TITLE
Adding publish-to-cdn action (GAUD-726)

### DIFF
--- a/publish-to-cdn/README.md
+++ b/publish-to-cdn/README.md
@@ -1,0 +1,66 @@
+# Publish To CDN Action
+
+This action leverages the [publish-to-s3](../publish-to-s3/) GitHub Action, and configures it specifically for publishing to the [Brightspace CDN](https://desire2learn.atlassian.net/wiki/spaces/DEVCENTRAL/pages/3314221651/Brightspace+CDN) (`https://s.brightspace.com`).
+
+Features:
+- Prevents existing files from being overwritten
+- Caches all assets for 1 year
+- Enables `public-read` access
+- Prefixes `bucket-path` with `s3://d2lprodcdn/`
+
+> [!IMPORTANT]  
+> Published files will be cached indefinitely, so ensure a mechanism for cache invalidation is present, such as a version number in the `cdn-path`. For example: `my-lib/<version>`.
+
+## Using the Action
+
+This action is typically triggered from a release workflow that runs on your `main` branch when a new release is created.
+
+To assume the correct role for publishing to the CDN and have the appropriate secrets available, set up the `cdn` capability [in repo-settings](https://github.com/Brightspace/repo-settings/blob/main/docs/cdn.md).
+
+Here's a sample workflow:
+
+```yml
+name: Publish
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: Brightspace/third-party-actions@actions/checkout
+      - name: Setup Node
+        uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version-file: .nvmrc
+      - name: Install dependencies
+        run: npm install
+      - name: Release
+        id: release
+        uses: <semantic/match-lms/incremental>
+      - name: Assume role
+        if: steps.release.outputs.VERSION != ''
+        uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+          role-to-assume: <role_that_can_upload_to_the_cdn>
+          role-duration-seconds: 3600
+          aws-region: ca-central-1
+      - name: Publish
+        if: steps.release.outputs.VERSION != ''
+        uses: BrightspaceUI/actions/publish-to-cdn@main
+        with:
+          cdn-path: my-lib/${{ steps.release.outputs.VERSION }}
+          publish-directory: ./build/
+```
+
+Options:
+
+* `cdn-path` (required): The path on the CDN beneath `s3://d2lprodcdn/`, to which to publish
+* `publish-directory` (required): The directory within your repo to publish to the CDN

--- a/publish-to-cdn/README.md
+++ b/publish-to-cdn/README.md
@@ -9,11 +9,11 @@ Features:
 - Prefixes `bucket-path` with `s3://d2lprodcdn/`
 
 > [!IMPORTANT]  
-> Published files will be cached indefinitely, so ensure a mechanism for cache invalidation is present, such as a version number in the `cdn-path`. For example: `my-lib/<version>`.
+> Published files will be cached indefinitely, so ensure a mechanism for cache invalidation is present, such as a version number in the `cdn-path`. For example: `<lib-name>/<version>`.
 
 ## Using the Action
 
-This action is typically triggered from a release workflow that runs on your `main` branch when a new release is created.
+This action is typically triggered from a release workflow that runs on a repo's `main` branch when a new release is created.
 
 To assume the correct role for publishing to the CDN and have the appropriate secrets available, set up the `cdn` capability [in repo-settings](https://github.com/Brightspace/repo-settings/blob/main/docs/cdn.md).
 
@@ -56,7 +56,7 @@ jobs:
         if: steps.release.outputs.VERSION != ''
         uses: BrightspaceUI/actions/publish-to-cdn@main
         with:
-          cdn-path: my-lib/${{ steps.release.outputs.VERSION }}
+          cdn-path: <lib-name>/${{ steps.release.outputs.VERSION }}
           publish-directory: ./build/
 ```
 

--- a/publish-to-cdn/action.yml
+++ b/publish-to-cdn/action.yml
@@ -27,5 +27,4 @@ runs:
         bucket-path: s3://d2lprodcdn/${{ inputs.cdn-path }}
         cache-default: --cache-control public,max-age=31536000,immutable
         publish-directory: ${{ inputs.publish-directory }}
-        only-log-errors: true
         public-read: true

--- a/publish-to-cdn/action.yml
+++ b/publish-to-cdn/action.yml
@@ -1,0 +1,31 @@
+name: Publish to CDN
+description: Publishes the specified directory to the Brightspace CDN
+
+inputs:
+  cdn-path:
+    description: The path on the CDN beneath `s3://d2lprodcdn/`, to which to publish
+    required: true
+  publish-directory:
+    description: The directory within your repo to publish to the CDN
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Overwrite Protection
+      run: |
+        if [[ $(aws s3 ls "s3://d2lprodcdn/${CDN_PATH}/" | head) ]]; then
+           echo "ERROR: cdn-path "\""$CDN_PATH"\"" already exists, which would result in files being overwritten. Choose a unique publish path.";
+           exit 1;
+        fi
+      shell: bash
+      env:
+        CDN_PATH: ${{ inputs.cdn-path }}
+    - name: Deploy
+      uses: BrightspaceUI/actions/publish-to-s3@main
+      with:
+        bucket-path: s3://d2lprodcdn/${{ inputs.cdn-path }}
+        cache-default: --cache-control public,max-age=31536000,immutable
+        publish-directory: ${{ inputs.publish-directory }}
+        only-log-errors: true
+        public-read: true


### PR DESCRIPTION
This introduces a new action specifically for publishing to the Brighspace CDN. We noticed that in almost all the new uses of `publish-to-s3`, caching of assets was desired by wasn't configured. This hopefully resolves that by tuning it specially for the CDN.

Additionally, this adds overwrite protection which [was present in the old frau-publisher](https://github.com/Brightspace/frau-publisher/blob/master/src/overwrite.js) to prevent overwriting existing things on the CDN.