### PR TITLE
automatically assume the role (GAUD-726)

### DIFF
--- a/publish-to-cdn/README.md
+++ b/publish-to-cdn/README.md
@@ -7,6 +7,7 @@ Features:
 - Caches all assets for 1 year
 - Enables `public-read` access
 - Prefixes `bucket-path` with `s3://d2lprodcdn/`
+- Automatically assumes the correct role for publishing
 
 > [!IMPORTANT]  
 > Published files will be cached indefinitely, so ensure a mechanism for cache invalidation is present, such as a version number in the `cdn-path`. For example: `<lib-name>/<version>`.
@@ -15,7 +16,7 @@ Features:
 
 This action is typically triggered from a release workflow that runs on a repo's `main` branch when a new release is created.
 
-To assume the correct role for publishing to the CDN and have the appropriate secrets available, set up the `cdn` capability [in repo-settings](https://github.com/Brightspace/repo-settings/blob/main/docs/cdn.md).
+To have the appropriate secrets available, set up the `cdn` capability [in repo-settings](https://github.com/Brightspace/repo-settings/blob/main/docs/cdn.md).
 
 Here's a sample workflow:
 
@@ -42,16 +43,6 @@ jobs:
       - name: Release
         id: release
         uses: <semantic/match-lms/incremental>
-      - name: Assume role
-        if: steps.release.outputs.VERSION != ''
-        uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          role-to-assume: <role_that_can_upload_to_the_cdn>
-          role-duration-seconds: 3600
-          aws-region: ca-central-1
       - name: Publish
         if: steps.release.outputs.VERSION != ''
         uses: BrightspaceUI/actions/publish-to-cdn@main

--- a/publish-to-cdn/README.md
+++ b/publish-to-cdn/README.md
@@ -47,11 +47,15 @@ jobs:
         if: steps.release.outputs.VERSION != ''
         uses: BrightspaceUI/actions/publish-to-cdn@main
         with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           cdn-path: <lib-name>/${{ steps.release.outputs.VERSION }}
           publish-directory: ./build/
 ```
 
 Options:
 
+* `aws-access-key-id`, `aws-secret-access-key`, `aws-session-token` (required): Set these to the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` repository secrets
 * `cdn-path` (required): The path on the CDN beneath `s3://d2lprodcdn/`, to which to publish
 * `publish-directory` (required): The directory within your repo to publish to the CDN

--- a/publish-to-cdn/action.yml
+++ b/publish-to-cdn/action.yml
@@ -30,13 +30,24 @@ runs:
       shell: bash
       env:
         CDN_PATH: ${{ inputs.cdn-path }}
+    - name: Determine Role Name
+      id: role-name
+      run: |
+        ORG_NAME="${{ github.repository_owner }}"
+        if [[ ${ORG_NAME} == "BrightspaceHypermediaComponents" ]]; then ORG_NAME="BHC"; fi
+
+        REPO_NAME="${{ github.repository }}"        
+        REPO_NAME="${REPO_NAME#*/}"
+
+        echo "value=arn:aws:iam::771734770799:role/r+$ORG_NAME+$REPO_NAME+repo" >> $GITHUB_OUTPUT
+      shell: bash
     - name: Assume role
       uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-session-token: ${{ inputs.aws-session-token }}
-        role-to-assume: "arn:aws:iam::771734770799:role/r+${{ github.repository }}+repo"
+        role-to-assume: "${{ steps.role-name.outputs.value }}"
         role-duration-seconds: 3600
         aws-region: us-east-1
     - name: Deploy

--- a/publish-to-cdn/action.yml
+++ b/publish-to-cdn/action.yml
@@ -21,6 +21,15 @@ runs:
       shell: bash
       env:
         CDN_PATH: ${{ inputs.cdn-path }}
+    - name: Assume role
+        uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+          role-to-assume: "arn:aws:iam::771734770799:role/r+${{ github.repository }}+repo"
+          role-duration-seconds: 3600
+          aws-region: us-east-1
     - name: Deploy
       uses: BrightspaceUI/actions/publish-to-s3@main
       with:

--- a/publish-to-cdn/action.yml
+++ b/publish-to-cdn/action.yml
@@ -2,6 +2,15 @@ name: Publish to CDN
 description: Publishes the specified directory to the Brightspace CDN
 
 inputs:
+  aws-access-key-id:
+    description: The AWS access key ID to use for publishing
+    required: true
+  aws-secret-access-key:
+    description: The AWS secret access key to use for publishing
+    required: true
+  aws-session-token:
+    description: The AWS session token to use for publishing
+    required: true
   cdn-path:
     description: The path on the CDN beneath `s3://d2lprodcdn/`, to which to publish
     required: true
@@ -22,14 +31,14 @@ runs:
       env:
         CDN_PATH: ${{ inputs.cdn-path }}
     - name: Assume role
-        uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          role-to-assume: "arn:aws:iam::771734770799:role/r+${{ github.repository }}+repo"
-          role-duration-seconds: 3600
-          aws-region: us-east-1
+      uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-session-token: ${{ inputs.aws-session-token }}
+        role-to-assume: "arn:aws:iam::771734770799:role/r+${{ github.repository }}+repo"
+        role-duration-seconds: 3600
+        aws-region: us-east-1
     - name: Deploy
       uses: BrightspaceUI/actions/publish-to-s3@main
       with:


### PR DESCRIPTION
Based on @j3parker's [suggestion here](https://github.com/Brightspace/repo-settings/pull/1575).

If the `771734770799` IAM is different based on the org (BrightspaceUI, Brightspace, BrightspaceHypermediaComponents, etc.) then this won't work.