### PR TITLE
switch to gzip compression algorithm (GAUD-697)

### DIFF
--- a/publish-to-s3/action.yml
+++ b/publish-to-s3/action.yml
@@ -62,7 +62,7 @@ runs:
       shell: bash
 
     - name: Compress
-      run: find $PUBLISH_DIRECTORY \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.json' -o -iname '*.svg' -o -iname '*.xml' \) -exec brotli {} \; -exec mv {}.br {} \;
+      run: find $PUBLISH_DIRECTORY \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.json' -o -iname '*.svg' -o -iname '*.xml' \) -exec gzip -9 -n {} \; -exec mv {}.gz {} \;
       env:
         PUBLISH_DIRECTORY: ${{ inputs.publish-directory }}
       shell: bash
@@ -87,7 +87,7 @@ runs:
         PUBLISH_DIRECTORY: ${{ inputs.publish-directory }}
         CACHE_POLICY: --cache-control public,max-age=31536000,immutable
         CACHE_DEFAULT: ${{ inputs.cache-default }}
-        COMPRESS_ENCODING: --content-encoding br
+        COMPRESS_ENCODING: --content-encoding gzip
         FILES_CACHE_ONLY: ${{ steps.parse-files.outputs.cache-only }}
         FILES_COMPRESS_AND_CACHE: ${{ steps.parse-files.outputs.compress-and-cache }}
         FILES_COMPRESS_ONLY: ${{ steps.parse-files.outputs.compress-only }}


### PR DESCRIPTION
Based [on this previous conversion](https://github.com/BrightspaceUI/documentation/pull/1130/files) in the Daylight repo.

This action is now being used for production-y things and we'd like to use it for even more (e.g. BSI) and retire `frau-publisher`. Unfortunately, browser support and general support (e.g. Powershell, .NET) just isn't quite there yet for Brotli and we ran into some issues with it. This switches to `gzip` which will result in slightly worse compression but can be used more widely.