### PR TITLE
set PUPPETEER_DOWNLOAD_BASE_URL to fix Chrome

### DIFF
--- a/visual-diff/action.yml
+++ b/visual-diff/action.yml
@@ -33,6 +33,7 @@ runs:
         echo -e "\e[34mInstalling Dependencies"
         NPM_PACKAGE=$(cut -d "=" -f 2 <<< $(npm run env | grep "npm_package_name"))
         if [ $NPM_PACKAGE != '@brightspace-ui/visual-diff' ]; then
+          PUPPETEER_DOWNLOAD_BASE_URL=https://storage.googleapis.com/chrome-for-testing-public
           npm install @brightspace-ui/visual-diff@14 --no-save
         fi
         npm install chalk@5 @octokit/rest@18 --prefix ${{ github.action_path }} --no-save --loglevel error


### PR DESCRIPTION
Chrome [moved where its downloads are](https://github.com/GoogleChromeLabs/chrome-for-testing/commit/dd90f461197402d01208a690b58f8a7776db6e7c), which is causing the older version of Puppeteer that we're still using to fail to find it.

This overrides the location to the new one, which will hopefully fix things until we EOL this library.