### PR TITLE
Fix reading directory as file warning

### DIFF
--- a/publish-to-s3/action.yml
+++ b/publish-to-s3/action.yml
@@ -62,7 +62,7 @@ runs:
       shell: bash
 
     - name: Compress
-      run: find $PUBLISH_DIRECTORY \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.json' -o -iname '*.svg' -o -iname '*.xml' \) -exec gzip -9 -n {} \; -exec mv {}.gz {} \;
+      run: find $PUBLISH_DIRECTORY -type f \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.json' -o -iname '*.svg' -o -iname '*.xml' \) -exec gzip -9 -n {} \; -exec mv {}.gz {} \;
       env:
         PUBLISH_DIRECTORY: ${{ inputs.publish-directory }}
       shell: bash


### PR DESCRIPTION
Noticed this while watching a copy to s3
```
failed to read input [./_site/internal/tags/node.js]: Is a directory
```
Since the folder ends in `.js` it tries to add it to the list of files to compress. This should make `find` only look for `file` types.