### PR TITLE
Remove `only-post-once` from documentation

### DIFF
--- a/comment-on-pr/README.md
+++ b/comment-on-pr/README.md
@@ -30,7 +30,6 @@ jobs:
 
 * `message` (required): The message to display
 * `post-mode` (default: `always`): How posting of the comment will be handled. Options are `always`, `once`, `hide-previous` or `update`. See [below](#post-mode) for details
-* `only-post-once` (default: `false`): This option is deprecated and should not be used going forward. Kept for backward compatibility. Will be removed in the future
 * `unique-key` (default: `"gh-actions_comment-on-pr"`): A unique key attached invisibly to the comment, for use with the `post-mode` option
 
 #### Post Mode

--- a/comment-on-pr/README.md
+++ b/comment-on-pr/README.md
@@ -30,7 +30,7 @@ jobs:
 
 * `message` (required): The message to display
 * `post-mode` (default: `always`): How posting of the comment will be handled. Options are `always`, `once`, `hide-previous` or `update`. See [below](#post-mode) for details
-* `unique-key` (default: `"gh-actions_comment-on-pr"`): A unique key attached invisibly to the comment, for use with the `post-mode` option
+* `unique-key` (default: `gh-actions_comment-on-pr`): A unique key attached invisibly to the comment, for use with the `post-mode` option
 
 #### Post Mode
 


### PR DESCRIPTION
[Last use of it was removed](https://github.com/search?q=%22BrightspaceUI%2Factions%2Fcomment-on-pr%22+%22only-post-once%22+NOT+repo%3ABrightspaceUI%2Factions+NOT+repo%3ABrightspace%2Fblog.d2l.dev+NOT+repo%3ABrightspaceGraveyard%2Ftest-reporting.d2l.dev&type=code). Leaving option in for now. Don't want to break recent release branches that may use the old option. Seems good to not advertise it though. Will remove fully after a few release.