### PR TITLE
GAUD-6130 - Allow for separate vdiff runs in the same repo

### DIFF
--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -169,8 +169,16 @@ runs:
         echo "Clearing .vdiff directory"
         rm -rf .vdiff
 
+        echo "Determine Starting Point"
+        STARTING_POINT="."
+        if [[ ${FILES} != "" ]]; then
+            TRIM_WILDCARDS=`echo ${FILES} | sed 's/\*.*//'`;
+            STARTING_POINT=`dirname "${TRIM_WILDCARDS}"`;
+        fi
+        echo ${STARTING_POINT}
+
         echo "Moving current goldens to .vdiff directory"
-        find . -name golden -type d | while read GOLDEN_DIR; do
+        find ${STARTING_POINT} -name golden -type d | while read GOLDEN_DIR; do
           TEST_PATH=`dirname "${GOLDEN_DIR}"`
           TEST_PATH=${TEST_PATH:2}
 
@@ -182,6 +190,7 @@ runs:
           done
         done
       env:
+        FILES: ${{ inputs.test-files }}
         FORCE_COLOR: 3
       shell: bash
 


### PR DESCRIPTION
Currently, we start at the root of a repo and find _every_ `golden` folder, and move it to the `.vdiff` folder before running the tests. This means you can't separate out vdiff tests into separate areas, and run them in parallel or at different points in your workflows, because that run will try to delete all the goldens from the other area. You can see that in [this run](https://github.com/BrightspaceUI/documentation/actions/runs/8382478914/job/22956329370?pr=1613#step:7:476), where it's deleting a bunch of files not in the test path it's currently running.

I guess we've never tried to do this anywhere yet, but this is how the Daylight site repo works. It runs some tests in CI and others on merge. [Here's an example](https://github.com/BrightspaceUI/documentation/actions/runs/8393214633) of a run pointing to this branch that worked. Both pointed to different paths and just moved those files, and opened up separate PRs to handle their goldens.