### PR TITLE
Add easy-to-copy link to the CDN file location

### DIFF
--- a/publish-to-cdn/action.yml
+++ b/publish-to-cdn/action.yml
@@ -57,3 +57,9 @@ runs:
         cache-default: --cache-control public,max-age=31536000,immutable
         publish-directory: ${{ inputs.publish-directory }}
         public-read: true
+    - name: Publish Complete
+      run: |
+        echo -e "\e[32mFiles available at:\e[0m https://s.brightspace.com/${CDN_PATH}\n"
+      shell: bash
+      env:
+        CDN_PATH: ${{ inputs.cdn-path }}


### PR DESCRIPTION
`frau-publisher` used to do something like this. Just gives an easy way to copy the public path to the CDN.