### PR TITLE
Cleanup logs a bit

### DIFF
--- a/publish-to-cdn/action.yml
+++ b/publish-to-cdn/action.yml
@@ -59,6 +59,7 @@ runs:
         public-read: true
     - name: Publish Complete
       run: |
+        # Display CDN location
         echo -e "\e[32mFiles available at:\e[0m https://s.brightspace.com/${CDN_PATH}\n"
       shell: bash
       env:


### PR DESCRIPTION
This is super nit-picky, but I just don't love how the action logs display the first line, which looks like garbage:
![image](https://github.com/BrightspaceUI/actions/assets/13419300/6c5d995c-d838-4c36-9fd9-d792da2b54f1)

So adding a comment to show that instead 🙈 