### PR TITLE
GAUD-6207 - Add slack notifications to update-package-lock

### DIFF
--- a/update-package-lock/README.md
+++ b/update-package-lock/README.md
@@ -84,8 +84,8 @@ You can receive slack notifications if the `update-package-lock` action fails (b
 If you set either of these inputs, you'll need to pass the `D2L_SLACK_TOKEN` secret to the `SLACK_TOKEN` input:
 ```
         with:
-          SLACK_CHANNEL_FAILURE: #my-channel
-          SLACK_CHANNEL_STALE_PR: #my-other-channel
+          SLACK_CHANNEL_FAILURE: '#my-channel'
+          SLACK_CHANNEL_STALE_PR: '#my-other-channel'
           SLACK_TOKEN: ${{ secrets.D2L_SLACK_TOKEN }}
 ```
 

--- a/update-package-lock/README.md
+++ b/update-package-lock/README.md
@@ -25,7 +25,7 @@ jobs:
           token: ${{ secrets.MY_GITHUB_TOKEN }}
       - uses: Brightspace/third-party-actions@actions/setup-node
         with:
-          node-version: '14'
+          node-version-file: .nvmrc
       - name: Update package-lock.json
         uses: BrightspaceUI/actions/update-package-lock@main
         with:
@@ -42,6 +42,9 @@ Options:
 * `DEFAULT_BRANCH` (default: `main`): Name of the default release branch for your repo.
 * `GITHUB_TOKEN` (required): Token for opening the updates PR. See [setup details](#setting-github-token) below.
 * `PR_TITLE` (default: `Updating package-lock.json`): Title for the opened pull request.
+* `SLACK_CHANNEL_FAILURE`: Optional slack channel to send action failures to
+* `SLACK_CHANNEL_STALE_PR`: Optional slack channel to send stale PR warnings to. A message will be sent if the action updates a PR that has been open for more than 3 days.
+* `SLACK_TOKEN`: Slack token for enabling slack notifications. Only needed if `SLACK_CHANNEL_FAILURE` and/or `SLACK_CHANNEL_STALE_PR` is set. See [setup details](#setting-slack-token) below.
 * `WORKING_DIRECTORY` (default: `.`): The directory to perform all actions within. Useful for repositories with more then one `package-lock.json`.
 
 ## Setting GITHUB_TOKEN
@@ -73,3 +76,17 @@ Like with [setting the `GITHUB_TOKEN` above](#setting-github-token), setting `AU
 ### Auto-Merge Method
 
 When using `AUTO_MERGE_METHOD` you must make sure the repository allows the method of merge selected, otherwise enabling auto merge will fail. By default all new repositories allow `merge` as the merge method hence the default for `AUTO_MERGE_METHOD`. For the merge method `squash` the commit message will be determined by the [squash commit message setting](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/configuring-commit-squashing-for-pull-requests) you have selected.
+
+## Setting SLACK_TOKEN
+
+You can receive slack notifications if the `update-package-lock` action fails (by setting `SLACK_CHANNEL_FAILURE`) or if the update PR is getting stale (by setting `SLACK_CHANNEL_STALE_PR`). This can be helpful if you are using auto-approval and auto-merge, and CODEOWNERS are not added to these PRs.
+
+If you set either of these inputs, you'll need to pass the `D2L_SLACK_TOKEN` secret to the `SLACK_TOKEN` input:
+```
+        with:
+          SLACK_CHANNEL_FAILURE: #my-channel
+          SLACK_CHANNEL_STALE_PR: #my-other-channel
+          SLACK_TOKEN: ${{ secrets.D2L_SLACK_TOKEN }}
+```
+
+For your repo to have access to `D2L_SLACK_TOKEN`, you'll need to set this up in [`repo-settings`](https://github.com/Brightspace/repo-settings/blob/main/docs/slack.md).

--- a/update-package-lock/action.yml
+++ b/update-package-lock/action.yml
@@ -159,13 +159,13 @@ runs:
               "icon_emoji": ":update-package-lock:",
               "unfurl_media": false,
               "unfurl_links": false,
-              "text": ":fire: ${{ github.repository }} -> Update failed (trigger: ${{ github.event_name }}, run attempt: ${{ github.run_attempt }}).\nSee ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} for details.",
+              "text": ":fire: ${{ github.repository }} -> Update run failed.\nSee ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} for details (trigger: ${{ github.event_name }}, run attempt: ${{ github.run_attempt }})",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":fire: `${{ github.repository }}` -> Update failed (trigger: `${{ github.event_name }}`, run attempt: ${{ github.run_attempt }}).\nSee the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run logs> for details."
+                    "text": ":fire: `${{ github.repository }}` -> Update run failed.\nSee the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run logs> for details (trigger: `${{ github.event_name }}`, run attempt: ${{ github.run_attempt }})"
                   }
                 }
               ]

--- a/update-package-lock/action.yml
+++ b/update-package-lock/action.yml
@@ -129,17 +129,17 @@ runs:
           channel-id: ${{ env.CHANNEL }}
           payload: >
             {
-              "username": "${{ github.repository }} -> Stale update-package-lock PR",
+              "username": "Stale update-package-lock PR",
               "icon_emoji": ":update-package-lock:",
               "unfurl_media": false,
               "unfurl_links": false,
-              "text": ":warning: PR #${{ env.PR_NUM }} (${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUM }}) to update the package-lock.json file has been open for more than 3 days.",
+              "text": ":warning: ${{ github.repository }} -> PR #${{ env.PR_NUM }} (${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUM }}) to update the package-lock.json file has been open for more than 3 days.",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":warning: <${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUM }}|PR #${{ env.PR_NUM }}> to update the `package-lock.json` file has been open for more than 3 days."
+                    "text": ":warning: `${{ github.repository }}` -> <${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUM }}|PR #${{ env.PR_NUM }}> to update the `package-lock.json` file has been open for more than 3 days."
                   }
                 }
               ]
@@ -155,17 +155,17 @@ runs:
           channel-id: ${{ env.CHANNEL }}
           payload: >
             {
-              "username": "${{ github.repository }} -> update-package-lock Issue",
+              "username": "update-package-lock Issue",
               "icon_emoji": ":update-package-lock:",
               "unfurl_media": false,
               "unfurl_links": false,
-              "text": ":fire: Update failed for ${{ github.event_name }} trigger (run attempt ${{ github.run_attempt }}). See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} for details.",
+              "text": ":fire: ${{ github.repository }} -> Update failed for ${{ github.event_name }} trigger (run attempt ${{ github.run_attempt }}). See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} for details.",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":fire: Update failed for `${{ github.event_name }}` trigger (run attempt ${{ github.run_attempt }}). See the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run logs> for details."
+                    "text": ":fire: `${{ github.repository }}` -> Update failed for `${{ github.event_name }}` trigger (run attempt ${{ github.run_attempt }}). See the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run logs> for details."
                   }
                 }
               ]

--- a/update-package-lock/action.yml
+++ b/update-package-lock/action.yml
@@ -129,7 +129,7 @@ runs:
           channel-id: ${{ env.CHANNEL }}
           payload: >
             {
-              "username": "Stale update-package-lock PR",
+              "username": "${{ github.repository }} Stale update-package-lock PR",
               "icon_emoji": ":update-package-lock:",
               "unfurl_media": false,
               "unfurl_links": false,
@@ -155,7 +155,7 @@ runs:
           channel-id: ${{ env.CHANNEL }}
           payload: >
             {
-              "username": "update-package-lock Issue",
+              "username": "${{ github.repository }} update-package-lock Issue",
               "icon_emoji": ":update-package-lock:",
               "unfurl_media": false,
               "unfurl_links": false,

--- a/update-package-lock/action.yml
+++ b/update-package-lock/action.yml
@@ -147,7 +147,7 @@ runs:
         env:
           CHANNEL: ${{ inputs.SLACK_CHANNEL_STALE_PR }}
           PR_NUM: ${{ steps.create-pr.outputs.pr-num }}
-          SLACK_BOT_TOKEN: ${{ inputs.D2L_SLACK_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ inputs.SLACK_TOKEN }}
       - name: Notify Slack About Workflow Failure
         if: ${{ failure() && inputs.SLACK_CHANNEL_FAILURE != '' && inputs.SLACK_TOKEN != '' }}
         uses: Brightspace/third-party-actions@slackapi/slack-github-action
@@ -172,4 +172,4 @@ runs:
             }
         env:
           CHANNEL: ${{ inputs.SLACK_CHANNEL_FAILURE }}
-          SLACK_BOT_TOKEN: ${{ inputs.D2L_SLACK_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ inputs.SLACK_TOKEN }}

--- a/update-package-lock/action.yml
+++ b/update-package-lock/action.yml
@@ -133,13 +133,13 @@ runs:
               "icon_emoji": ":update-package-lock:",
               "unfurl_media": false,
               "unfurl_links": false,
-              "text": ":warning: ${{ github.repository }} -> PR #${{ env.PR_NUM }} (${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUM }}) to update the package-lock.json file has been open for more than 3 days.",
+              "text": ":warning: ${{ github.repository }} -> PR #${{ env.PR_NUM }} (${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUM }}) to update package-lock.json has been open for more than 3 days.",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":warning: `${{ github.repository }}` -> <${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUM }}|PR #${{ env.PR_NUM }}> to update the `package-lock.json` file has been open for more than 3 days."
+                    "text": ":warning: `${{ github.repository }}` -> <${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUM }}|PR #${{ env.PR_NUM }}> to update `package-lock.json` has been open for more than 3 days."
                   }
                 }
               ]
@@ -159,13 +159,13 @@ runs:
               "icon_emoji": ":update-package-lock:",
               "unfurl_media": false,
               "unfurl_links": false,
-              "text": ":fire: ${{ github.repository }} -> Update failed for ${{ github.event_name }} trigger (run attempt ${{ github.run_attempt }}). See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} for details.",
+              "text": ":fire: ${{ github.repository }} -> Update failed (trigger: ${{ github.event_name }}, run attempt: ${{ github.run_attempt }}).\nSee ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} for details.",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":fire: `${{ github.repository }}` -> Update failed for `${{ github.event_name }}` trigger (run attempt ${{ github.run_attempt }}). See the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run logs> for details."
+                    "text": ":fire: `${{ github.repository }}` -> Update failed (trigger: `${{ github.event_name }}`, run attempt: ${{ github.run_attempt }}).\nSee the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run logs> for details."
                   }
                 }
               ]

--- a/update-package-lock/action.yml
+++ b/update-package-lock/action.yml
@@ -129,7 +129,7 @@ runs:
           channel-id: ${{ env.CHANNEL }}
           payload: >
             {
-              "username": "${{ github.repository }} Stale update-package-lock PR",
+              "username": "${{ github.repository }} -> Stale update-package-lock PR",
               "icon_emoji": ":update-package-lock:",
               "unfurl_media": false,
               "unfurl_links": false,
@@ -155,7 +155,7 @@ runs:
           channel-id: ${{ env.CHANNEL }}
           payload: >
             {
-              "username": "${{ github.repository }} update-package-lock Issue",
+              "username": "${{ github.repository }} -> update-package-lock Issue",
               "icon_emoji": ":update-package-lock:",
               "unfurl_media": false,
               "unfurl_links": false,

--- a/update-package-lock/action.yml
+++ b/update-package-lock/action.yml
@@ -25,6 +25,12 @@ inputs:
   PR_TITLE:
     description: Title for the opened pull request
     default: 'Updating package-lock.json'
+  SLACK_CHANNEL_FAILURE:
+    description: Slack channel to send action failures to (will skip if not provided)
+  SLACK_CHANNEL_STALE_PR:
+    description: Slack channel to send stale PR warnings to (will skip if not provided)
+  SLACK_TOKEN:
+    description: Slack token for enabling slack notifications (will skip if not provided)
   WORKING_DIRECTORY:
     description: Path where you want to execute the update action
     default: '.'
@@ -42,7 +48,7 @@ runs:
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         run: |
           echo -e "\e[34mInstalling Dependencies"
-          npm install chalk@5 @octokit/graphql@4 --prefix ${{ github.action_path }} --no-save --loglevel error
+          npm install chalk@5 @octokit/graphql@4 @actions/core@1 --prefix ${{ github.action_path }} --no-save --loglevel error
         shell: bash
       - name: Checkout Branch
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
@@ -95,6 +101,7 @@ runs:
           NODE_AUTH_TOKEN: ${{ inputs.NODE_AUTH_TOKEN }}
         shell: bash
       - name: Create PR (if necessary)
+        id: create-pr
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         run: |
           if [ ${{ steps.check-for-changes.outputs.changes-exist }} == false ]; then
@@ -115,3 +122,54 @@ runs:
           GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
           PR_TITLE: ${{ inputs.PR_TITLE }}
         shell: bash
+      - name: Notify Slack About Stale PR (if necessary)
+        if: ${{ steps.create-pr.outputs.stale == 'true' && inputs.SLACK_CHANNEL_STALE_PR != '' && inputs.SLACK_TOKEN != '' }}
+        uses: Brightspace/third-party-actions@slackapi/slack-github-action
+        with:
+          channel-id: ${{ env.CHANNEL }}
+          payload: >
+            {
+              "username": "Stale update-package-lock PR",
+              "icon_emoji": ":update-package-lock:",
+              "unfurl_media": false,
+              "unfurl_links": false,
+              "text": ":warning: PR #${{ env.PR_NUM }} (${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUM }}) to update the package-lock.json file has been open for more than 3 days.",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: <${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUM }}|PR #${{ env.PR_NUM }}> to update the `package-lock.json` file has been open for more than 3 days."
+                  }
+                }
+              ]
+            }
+        env:
+          CHANNEL: ${{ inputs.SLACK_CHANNEL_STALE_PR }}
+          PR_NUM: ${{ steps.create-pr.outputs.pr-num }}
+          SLACK_BOT_TOKEN: ${{ inputs.D2L_SLACK_TOKEN }}
+      - name: Notify Slack About Workflow Failure
+        if: ${{ failure() && inputs.SLACK_CHANNEL_FAILURE != '' && inputs.SLACK_TOKEN != '' }}
+        uses: Brightspace/third-party-actions@slackapi/slack-github-action
+        with:
+          channel-id: ${{ env.CHANNEL }}
+          payload: >
+            {
+              "username": "update-package-lock Issue",
+              "icon_emoji": ":update-package-lock:",
+              "unfurl_media": false,
+              "unfurl_links": false,
+              "text": ":fire: Update failed for ${{ github.event_name }} trigger (run attempt ${{ github.run_attempt }}). See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} for details.",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":fire: Update failed for `${{ github.event_name }}` trigger (run attempt ${{ github.run_attempt }}). See the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run logs> for details."
+                  }
+                }
+              ]
+            }
+        env:
+          CHANNEL: ${{ inputs.SLACK_CHANNEL_FAILURE }}
+          SLACK_BOT_TOKEN: ${{ inputs.D2L_SLACK_TOKEN }}

--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -141,7 +141,7 @@ async function handlePR() {
 
 	if (existingPr) {
 		console.log(`PR for branch ${branchName} already exists: #${existingPr.node.number}.`);
-		const threeDays = 1000 * 60 * 60; // 1000 * 60 * 60 * 24 * 3
+		const threeDays = 1000 * 60 * 60 * 24 * 3;
 		if (new Date() - new Date(existingPr.node.createdAt) > threeDays) {
 			console.log('PR has been open for more than 3 days.');
 			setOutput('stale', 'true');

--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -141,7 +141,7 @@ async function handlePR() {
 
 	if (existingPr) {
 		console.log(`PR for branch ${branchName} already exists: #${existingPr.node.number}.`);
-		const threeDays = 1000 * 60 * 60 * 24 * 3;
+		const threeDays = 1000 * 60 * 60; // 1000 * 60 * 60 * 24 * 3
 		if (new Date() - new Date(existingPr.node.createdAt) > threeDays) {
 			console.log('PR has been open for more than 3 days.');
 			core.setOutput('stale', 'true');

--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -144,8 +144,8 @@ async function handlePR() {
 		const threeDays = 1000 * 60 * 60; // 1000 * 60 * 60 * 24 * 3
 		if (new Date() - new Date(existingPr.node.createdAt) > threeDays) {
 			console.log('PR has been open for more than 3 days.');
-			core.setOutput('stale', 'true');
-			core.setOutput('pr-num', existingPr.node.number);
+			setOutput('stale', 'true');
+			setOutput('pr-num', existingPr.node.number);
 		}
 
 		try {


### PR DESCRIPTION
Add inputs to `update-package-lock` to tell the action to:
- Optionally send a slack message to the channel of your choice when it fails
- Optionally send a slack message to the channel of your choice when it pushes to an `update-package-lock` PR that has been open for more than three days
  - This is useful if you have turned off CODEOWNER review for these PRs to auto-merge themselves
  - CI in the repo might be flaky and this PR might be about to pass CI and merge itself, but we don't have a great way to catch actual dependency changes that are breaking something, or a PR that GitHub silently failed to turn on auto-merge for

I've tested this in `repo-data` and `fra-dashboard` pointing to this branch. Here's what the messages look like:
![image](https://github.com/BrightspaceUI/actions/assets/13419300/2e12fc83-6369-4842-b479-b733afcceb35)
