### PR TITLE
Add comment id as output to comment on PR action

### DIFF
--- a/comment-on-pr/README.md
+++ b/comment-on-pr/README.md
@@ -41,3 +41,7 @@ Every comment from this action includes a hidden key in an HTML comment, which i
 * `once`: The first time the action is run it will post the comment but in subsequent runs it will not post anything
 * `hide-previous`: This will always look for a previous comment with the specified `unique-key` and hide it before posting a new comment with the most recent content
 * `update`: This will find a previous comment with the specified `unique-key` and update the contents of the comment
+
+### Outputs
+
+* `comment-id`: This will be the ID of any comment that was created or updated. If no comment was created or updated this will be empty

--- a/comment-on-pr/action.yml
+++ b/comment-on-pr/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: The number of the pull request to post the comment to
     default: ${{ github.event.pull_request.number }}
     required: true
+outputs:
+  comment-id:
+    description: The ID of the comment that was created or updated
+    value: ${{steps.hc.outputs.id}}
 runs:
   using: composite
   steps:
@@ -55,6 +59,7 @@ runs:
         issue-number: ${{ inputs.pull-request-number }}
         starts-with: ${{ steps.in.outputs.unique-key }}
     - name: Handle PR comment
+      id: hc
       if: steps.fc.outputs.comment-id == '' || steps.in.outputs.post-mode != 'once'
       uses: Brightspace/third-party-actions@actions/github-script
       env:
@@ -73,11 +78,13 @@ runs:
               repo: context.repo.repo,
               body
             });
+            core.setOutput('id', COMMENT_ID);
           } else {
-            github.rest.issues.createComment({
+            const { data: { id } } = await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body
             });
+            core.setOutput('id', id);
           }

--- a/comment-on-pr/action.yml
+++ b/comment-on-pr/action.yml
@@ -24,7 +24,7 @@ inputs:
 outputs:
   comment-id:
     description: The ID of the comment that was created or updated
-    value: ${{steps.hc.outputs.id}}
+    value: ${{ steps.hc.outputs.id }}
 runs:
   using: composite
   steps:

--- a/comment-on-pr/action.yml
+++ b/comment-on-pr/action.yml
@@ -72,7 +72,7 @@ runs:
           const { MESSAGE, UNIQUE_KEY, POST_MODE, COMMENT_ID } = process.env;
           const body = `${UNIQUE_KEY}\n\n${MESSAGE}`;
           if (POST_MODE === 'update' && COMMENT_ID !== '') {
-            github.rest.issues.updateComment({
+            await github.rest.issues.updateComment({
               comment_id: COMMENT_ID,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
This is useful mainly for testing. I have action that internally use this action and I want to validate that they generate the correct comment. Having the ID means I can easily grab the comment my action made and validate it's contents. Validated with https://github.com/Brightspace/test-actions/pull/44.