### PR TITLE
GAUD-6310: pass through AWS credentials

### DIFF
--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -39,13 +39,15 @@ jobs:
 
 Options:
 
+* `aws-access-key-id`: Access key id for the role that will read release info, required for MINOR_RELEASE_WITH_LMS
+* `aws-secret-access-key`: Access key secret for the role that will read release info, required for MINOR_RELEASE_WITH_LMS
+* `aws-session-token`: Session token for the role that will read release info, required for MINOR_RELEASE_WITH_LMS
 * `DEFAULT_BRANCH` (default: `"main"`): name of the default release branch
 * `DRY_RUN` (default: `false`): Runs semantic-release with the `--dry-run` flag to simulate a release but not actually do one
 * `GITHUB_TOKEN`: Token to use to update version in 'package.json' and create GitHub release -- see section below on the release token for more details
-* `MINOR_RELEASE_WITH_LMS` (default: `false`): Automatically perform a minor release whenever the LMS release changes (requires `RALLY_API_KEY`)
+* `MINOR_RELEASE_WITH_LMS` (default: `false`): Automatically perform a minor release whenever the LMS release changes (requires `aws-access-key-id`, `aws-secret-access-key` and `aws-session-token` to be passed)
 * `NPM` (default: `false`): Whether or not to release as an NPM package (see "NPM Package Deployment" below for more info)
 * `NPM_TOKEN` (optional if `NPM` is `false` or publishing to CodeArtifact): Token to publish to NPM (see "NPM Package Deployment" below for more info)
-* `RALLY_API_KEY`: Key to access the Rally API, required for `MINOR_RELEASE_WITH_LMS`
 
 Outputs:
 * `VERSION`: will contain the new version number if a release occurred, empty otherwise
@@ -139,6 +141,6 @@ When the LMS version changes -- for example from `20.22.6` to `20.22.7` -- it ca
 
 This ensures that if a patch is required for the previous LMS version in the future, there's room in the version scheme to fit it in.
 
-To enable this feature, set the `MINOR_RELEASE_WITH_LMS` input to `true` and pass in `RALLY_API_KEY`, which will be set as an organization secret.
+To enable this feature, set the `MINOR_RELEASE_WITH_LMS` input to `true` and pass `aws-access-key-id`, `aws-secret-access-key` and `aws-session-token`.
 
 The workflow will then add a `.lmsrelease` file to source control. When the value in that file differs from the current active LMS release, a minor release will automaticaly occur.

--- a/semantic-release/action.yml
+++ b/semantic-release/action.yml
@@ -1,6 +1,12 @@
 name: Semantic Release
 description: Deploy using semantic-release
 inputs:
+  aws-access-key-id:
+    description: Access key id for the role that will read release info, required for MINOR_RELEASE_WITH_LMS
+  aws-secret-access-key:
+    description: Access key secret for the role that will read release info, required for MINOR_RELEASE_WITH_LMS
+  aws-session-token:
+    description: Session token for the role that will read release info, required for MINOR_RELEASE_WITH_LMS
   DEFAULT_BRANCH:
     description: name of the default release branch
     default: main
@@ -11,7 +17,7 @@ inputs:
     description: Token to use to update version in 'package.json' and create GitHub release
     required: true
   MINOR_RELEASE_WITH_LMS:
-    description: Automatically perform a minor release whenever the LMS release changes (requires RALLY_API_KEY)
+    description: Automatically perform a minor release whenever the LMS release changes
     default: false
   NPM:
     description: Whether or not to release as an NPM package
@@ -45,6 +51,9 @@ runs:
       id: get-lms-version
       uses: Brightspace/lms-version-actions/get-lms-release@main
       with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-session-token: ${{ inputs.aws-session-token }}
         RALLY_API_KEY: ${{ inputs.RALLY_API_KEY }}
     - name: Update Repo's Last LMS Release
       if: ${{ inputs.MINOR_RELEASE_WITH_LMS == 'true' && steps.get-maintenance-version.outputs.IS_MAINTENANCE_BRANCH != 'true' && inputs.DRY_RUN == 'false' && steps.repo-lms-version.outputs.VALUE != steps.get-lms-version.outputs.LMS_VERSION }}


### PR DESCRIPTION
Now that [get-lms-version](https://github.com/Brightspace/lms-version-actions/pull/33) can use a non-Rally source, we want to pass AWS credentials from `semantic-release` as well in cases where the `MINOR_RELEASE_WITH_LMS` is in play.

This change will initially have no effect since `RALLY_API_KEY` will also be passed and that bypasses the new logic. However, it'll enable us to switch the downstream repos one at a time to no longer pass it, and once that's done we can remove `RALLY_API_KEY` entirely from this action.