### PR TITLE
Improve display of dependency changes when exceeding max length

### DIFF
--- a/update-package-lock/handle-pr.js
+++ b/update-package-lock/handle-pr.js
@@ -135,7 +135,12 @@ async function handlePR() {
 	let prBody = 'Automatic update of the \`package-lock.json\` file.';
 	const prDependencyDiff = getDependencyDiff();
 
-	if (prDependencyDiff !== '' && (prBody.length + prDependencyDiff.length) < prDescriptionMaxSize) {
+	if ((prBody.length + prDependencyDiff.length) > prDescriptionMaxSize) {
+		prBody += '\n> [!WARNING]\n> Dependency Changes exceed max description length and have been truncated.\n\n';
+		const maxLength = prDescriptionMaxSize - prBody.length;
+		const truncatedLength = prDependencyDiff.lastIndexOf('\n', maxLength);
+		prBody += prDependencyDiff.slice(0, truncatedLength !== -1 ? truncatedLength : maxLength);
+	} else if (prDependencyDiff !== '') {
 		prBody += prDependencyDiff;
 	}
 


### PR DESCRIPTION
We [had a PR](https://github.com/Brightspace/parent-portal-ui/pull/1417) with no summary of changes, and I was wondering why we it didn't have one so I checked the code.

I've updated the logic to include a warning and as much of the changes as possible, when the change-list exceeds the max length.