### PR TITLE
VDiff action only commit files we care about

### DIFF
--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -330,7 +330,8 @@ runs:
         echo -e "\n\e[34mCommitting new goldens"
         git config user.name github-actions[bot]
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-        git add .
+        git reset HEAD
+        git add *.png ./.vdiff.json
         git commit -m 'Updating vdiff goldens'
 
         echo -e "\n\e[34mPushing the vdiff Branch"


### PR DESCRIPTION
When adding test reporting to `@brightspace-ui/testing` I noticed that generating the report by default ment it would get commited as part of this actions workflow if not in the `.gitignore`. We don't want that. With it on by default a bunch of repos will start generating this report but not submitting it (need teams to add an action to do so). In the meantime I want to start generating the report for "free" sdo convincing teams to submit it to our backend is as little work as possible.

Tested in https://github.com/BrightspaceUI/core/pull/4863.