### PR TITLE
`vdiff`: Detect orphaned goldens and remove them

### DIFF
--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -280,8 +280,7 @@ runs:
           mv "${PASS_DIR}/"* "./${TEST_PATH}/golden/${TEST}"
         done
 
-        if [[ ${COUNT_MISMATCH} = true ]]; then
-        echo -e "\e[31mGolden count has changed."
+        if [[ ${COUNT_MISMATCH} = true ]]; then echo -e "\e[31mGolden count has changed."; fi
 
         echo "Moving failed screenshots to golden directories"
         find ./.vdiff -name fail -type d | while read FAIL_DIR; do

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -269,7 +269,7 @@ runs:
           echo "Passed test count:"
           echo $(ls ${PASS_DIR} | wc -l | xargs)
           echo "Existing golden count:"
-          echo $(ls ${TEST_PATH}/golden/${TEST} | wc -l | xargs)
+          echo $(ls ${PASS_DIR}/../golden | wc -l | xargs)
 
           mkdir -p "./${TEST_PATH}/golden/${TEST}"
           mv "${PASS_DIR}/"* "./${TEST_PATH}/golden/${TEST}"

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -256,6 +256,7 @@ runs:
         only-log-errors: true
 
     - name: Move New Goldens
+      id: move-goldens
       run: |
         echo -e "\e[34mMoving New Goldens to Proper Directories"
 
@@ -266,10 +267,9 @@ runs:
           TEST_PATH=${TEST_PATH:9}
           TEST=`basename "${DIR}"`
 
-          echo "Passed test count:"
-          echo $(find ${PASS_DIR} -type f | wc -l | xargs)
-          echo "Existing golden count:"
-          echo $(find ${PASS_DIR}/../golden -type f | wc -l | xargs)
+          PASSED_COUNT=$(find ${PASS_DIR} -type f | wc -l | xargs)
+          GOLDEN_COUNT $(find ${PASS_DIR}/../golden -type f | wc -l | xargs)
+          if [[ PASSED_COUNT != GOLDEN_COUNT ]]; then echo "passed=true" >> ${GITHUB_OUTPUT} || echo "passed=false" >> ${GITHUB_OUTPUT}
 
           mkdir -p "./${TEST_PATH}/golden/${TEST}"
           mv "${PASS_DIR}/"* "./${TEST_PATH}/golden/${TEST}"
@@ -348,7 +348,7 @@ runs:
         FORCE_COLOR: 3
         ORIGINAL_SHA: ${{ steps.run-info.outputs.original-sha }}
         SOURCE_BRANCH: ${{ steps.run-info.outputs.source-branch }}
-        TESTS_PASSED: ${{ steps.test-run.outputs.passed }}
+        TESTS_PASSED: ${{ steps.test-run.outputs.passed && steps.move-goldens.outputs.passed }}
         VDIFF_BRANCH: ${{ steps.run-info.outputs.vdiff-branch }}
       shell: bash
 
@@ -364,7 +364,7 @@ runs:
       env:
         FORCE_COLOR: 3
         GOLDENS_CONFLICT: ${{ steps.commit-goldens.outputs.conflict }}
-        TESTS_PASSED: ${{ steps.test-run.outputs.passed }}
+        TESTS_PASSED: ${{ steps.test-run.outputs.passed && steps.move-goldens.outputs.passed }}
         VDIFF_BRANCH: ${{ steps.run-info.outputs.vdiff-branch }}
       shell: bash
 
@@ -491,7 +491,7 @@ runs:
         REPORT_PATH: https://vdiff.d2l.dev/${{ steps.prepare-report.outputs.upload-path }}/report/
         REPORT_UPLOADED: ${{ steps.upload-report.outcome }}
         SOURCE_BRANCH: ${{ steps.run-info.outputs.source-branch }}
-        TESTS_PASSED: ${{ steps.test-run.outputs.passed }}
+        TESTS_PASSED: ${{ steps.test-run.outputs.passed && steps.move-goldens.outputs.passed }}
         VDIFF_BRANCH: ${{ steps.run-info.outputs.vdiff-branch }}
 
     - name: Update Commit Status
@@ -551,5 +551,5 @@ runs:
         GOLDENS_CONFLICT: ${{ steps.commit-goldens.outputs.conflict }}
         ORIGINAL_SHA: ${{ steps.run-info.outputs.original-sha }}
         PULL_REQUEST_NUM: ${{ steps.pull-request.outputs.num }}
-        TESTS_PASSED: ${{ steps.test-run.outputs.passed }}
+        TESTS_PASSED: ${{ steps.test-run.outputs.passed && steps.move-goldens.outputs.passed }}
         COMMIT_STATUS_NAME: ${{ steps.commit-status-name.outputs.result }}

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -266,6 +266,11 @@ runs:
           TEST_PATH=${TEST_PATH:9}
           TEST=`basename "${DIR}"`
 
+          echo "Passed test count:"
+          echo $(ls ${PASS_DIR} | wc -l | xargs)
+          echo "Existing golden count:"
+          echo $(ls ${TEST_PATH}/golden/${TEST}} | wc -l | xargs)
+
           mkdir -p "./${TEST_PATH}/golden/${TEST}"
           mv "${PASS_DIR}/"* "./${TEST_PATH}/golden/${TEST}"
         done

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -272,9 +272,13 @@ runs:
           GOLDEN_COUNT=$(find ${PASS_DIR}/../golden -type f | wc -l | xargs)
           echo "passed=true" >> ${GITHUB_OUTPUT}
           if [[ ${PASSED_COUNT} != ${GOLDEN_COUNT} ]]; then
+            echo "passed=false" >> ${GITHUB_OUTPUT}
             COUNT_MISMATCH=true
-            echo "passed=false" >> ${GITHUB_OUTPUT};
           fi
+
+          echo "passed: ${PASSED_COUNT}"
+          echo "original: ${GOLDEN_COUNT}"
+          echo $COUNT_MISMATCH
 
           mkdir -p "./${TEST_PATH}/golden/${TEST}"
           mv "${PASS_DIR}/"* "./${TEST_PATH}/golden/${TEST}"

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -263,7 +263,7 @@ runs:
         echo "Moving passed screenshots back to golden directories"
         COUNT_MISMATCH=false
         echo "passed=true" >> ${GITHUB_OUTPUT}
-        find ./.vdiff -name pass -type d | while read PASS_DIR; do
+        while read PASS_DIR; do
           DIR=`dirname "${PASS_DIR}"`
           TEST_PATH=`dirname "${DIR}"`
           TEST_PATH=${TEST_PATH:9}
@@ -282,7 +282,7 @@ runs:
 
           mkdir -p "./${TEST_PATH}/golden/${TEST}"
           mv "${PASS_DIR}/"* "./${TEST_PATH}/golden/${TEST}"
-        done
+        done <<< "$(find ./.vdiff -name pass -type d)"
 
         echo $COUNT_MISMATCH
         if [[ $COUNT_MISMATCH = true ]]; then echo -e "\e[31mGolden count has changed"; fi

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -267,9 +267,9 @@ runs:
           TEST=`basename "${DIR}"`
 
           echo "Passed test count:"
-          echo $(ls ${PASS_DIR} | wc -l | xargs)
+          echo $(find ${PASS_DIR} -type f | wc -l | xargs)
           echo "Existing golden count:"
-          echo $(ls ${PASS_DIR}/../golden | wc -l | xargs)
+          echo $(find ${PASS_DIR}/../golden -type f | wc -l | xargs)
 
           mkdir -p "./${TEST_PATH}/golden/${TEST}"
           mv "${PASS_DIR}/"* "./${TEST_PATH}/golden/${TEST}"

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -268,7 +268,7 @@ runs:
           TEST=`basename "${DIR}"`
 
           PASSED_COUNT=$(find ${PASS_DIR} -type f | wc -l | xargs)
-          GOLDEN_COUNT $(find ${PASS_DIR}/../golden -type f | wc -l | xargs)
+          GOLDEN_COUNT=$(find ${PASS_DIR}/../golden -type f | wc -l | xargs)
           if [[ PASSED_COUNT != GOLDEN_COUNT ]]; then echo "passed=true" >> ${GITHUB_OUTPUT} || echo "passed=false" >> ${GITHUB_OUTPUT}; fi
 
           mkdir -p "./${TEST_PATH}/golden/${TEST}"

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -261,6 +261,7 @@ runs:
         echo -e "\e[34mMoving New Goldens to Proper Directories"
 
         echo "Moving passed screenshots back to golden directories"
+        COUNT_MISMATCH=false
         find ./.vdiff -name pass -type d | while read PASS_DIR; do
           DIR=`dirname "${PASS_DIR}"`
           TEST_PATH=`dirname "${DIR}"`
@@ -269,11 +270,18 @@ runs:
 
           PASSED_COUNT=$(find ${PASS_DIR} -type f | wc -l | xargs)
           GOLDEN_COUNT=$(find ${PASS_DIR}/../golden -type f | wc -l | xargs)
-          if [[ PASSED_COUNT != GOLDEN_COUNT ]]; then echo "passed=true" >> ${GITHUB_OUTPUT} || echo "passed=false" >> ${GITHUB_OUTPUT}; fi
+          echo "passed=true" >> ${GITHUB_OUTPUT}
+          if [[ ${PASSED_COUNT} != ${GOLDEN_COUNT} ]]; then
+            COUNT_MISMATCH=true
+            echo "passed=false" >> ${GITHUB_OUTPUT};
+          fi
 
           mkdir -p "./${TEST_PATH}/golden/${TEST}"
           mv "${PASS_DIR}/"* "./${TEST_PATH}/golden/${TEST}"
         done
+
+        if [[ ${COUNT_MISMATCH} = true ]]; then
+        echo -e "\e[31mGolden count has changed."
 
         echo "Moving failed screenshots to golden directories"
         find ./.vdiff -name fail -type d | while read FAIL_DIR; do

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -269,7 +269,7 @@ runs:
 
           PASSED_COUNT=$(find ${PASS_DIR} -type f | wc -l | xargs)
           GOLDEN_COUNT $(find ${PASS_DIR}/../golden -type f | wc -l | xargs)
-          if [[ PASSED_COUNT != GOLDEN_COUNT ]]; then echo "passed=true" >> ${GITHUB_OUTPUT} || echo "passed=false" >> ${GITHUB_OUTPUT}
+          if [[ PASSED_COUNT != GOLDEN_COUNT ]]; then echo "passed=true" >> ${GITHUB_OUTPUT} || echo "passed=false" >> ${GITHUB_OUTPUT}; fi
 
           mkdir -p "./${TEST_PATH}/golden/${TEST}"
           mv "${PASS_DIR}/"* "./${TEST_PATH}/golden/${TEST}"

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -262,6 +262,7 @@ runs:
 
         echo "Moving passed screenshots back to golden directories"
         COUNT_MISMATCH=false
+        echo "passed=true" >> ${GITHUB_OUTPUT}
         find ./.vdiff -name pass -type d | while read PASS_DIR; do
           DIR=`dirname "${PASS_DIR}"`
           TEST_PATH=`dirname "${DIR}"`
@@ -270,7 +271,6 @@ runs:
 
           PASSED_COUNT=$(find ${PASS_DIR} -type f | wc -l | xargs)
           GOLDEN_COUNT=$(find ${PASS_DIR}/../golden -type f | wc -l | xargs)
-          echo "passed=true" >> ${GITHUB_OUTPUT}
           if [[ ${PASSED_COUNT} != ${GOLDEN_COUNT} ]]; then
             echo "passed=false" >> ${GITHUB_OUTPUT}
             COUNT_MISMATCH=true
@@ -284,7 +284,8 @@ runs:
           mv "${PASS_DIR}/"* "./${TEST_PATH}/golden/${TEST}"
         done
 
-        if [[ ${COUNT_MISMATCH} = true ]]; then echo -e "\e[31mGolden count has changed."; fi
+        echo $COUNT_MISMATCH
+        if [[ $COUNT_MISMATCH = true ]]; then echo -e "\e[31mGolden count has changed"; fi
 
         echo "Moving failed screenshots to golden directories"
         find ./.vdiff -name fail -type d | while read FAIL_DIR; do

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -269,7 +269,7 @@ runs:
           echo "Passed test count:"
           echo $(ls ${PASS_DIR} | wc -l | xargs)
           echo "Existing golden count:"
-          echo $(ls ${TEST_PATH}/golden/${TEST}} | wc -l | xargs)
+          echo $(ls ${TEST_PATH}/golden/${TEST} | wc -l | xargs)
 
           mkdir -p "./${TEST_PATH}/golden/${TEST}"
           mv "${PASS_DIR}/"* "./${TEST_PATH}/golden/${TEST}"

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -276,15 +276,10 @@ runs:
             COUNT_MISMATCH=true
           fi
 
-          echo "passed: ${PASSED_COUNT}"
-          echo "original: ${GOLDEN_COUNT}"
-          echo $COUNT_MISMATCH
-
           mkdir -p "./${TEST_PATH}/golden/${TEST}"
           mv "${PASS_DIR}/"* "./${TEST_PATH}/golden/${TEST}"
         done <<< "$(find ./.vdiff -name pass -type d)"
 
-        echo $COUNT_MISMATCH
         if [[ $COUNT_MISMATCH = true ]]; then echo -e "\e[31mGolden count has changed"; fi
 
         echo "Moving failed screenshots to golden directories"


### PR DESCRIPTION
Currently we only create a vdiff PR if one or more tests fail. This means if everything passes but some tests were removed, orphaned goldens will remain in the repo until some subsequent run that has failed vdiff tests.

This detects the orphaned goldens and forces the workflow to procede as if some tests had failed.

[Example result](https://github.com/BrightspaceUI/testing/pull/496/files) - Everything in the report passes but the PR still removes the orphaned goldens.