### PR TITLE
t9n-fomat: Add `locales` input/flag

### DIFF
--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -19,6 +19,9 @@ inputs:
   t9n-quotes:
     description: Replace quote characters with locale-appropriate characters ("source", "straight", or "both")
     default: 'straight'
+  t9n-locales:
+    description: Comma-separated list of locales to format
+    default: ''
 
   draft-pr:
     description: Whether to open the translation formatting PR as a draft PR
@@ -160,11 +163,13 @@ runs:
       if: ${{ inputs.t9n-newlines != 'false' }}
       run: |
         echo -e "\e[34mFormatting translations - Newlines"
-        if [[ ${NEWLINES} == "true" ]]; then FLAGS="--newlines "; fi
+        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales '${LOCALES}' "; fi
+        if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
 
         npx mfv format ${FLAGS}
       env:
         NEWLINES: ${{ inputs.t9n-newlines }}
+        LOCALES: ${{ inputs.t9n-locales }}
       shell: bash
     - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
       if: ${{ inputs.t9n-newlines != 'false' }}
@@ -179,11 +184,13 @@ runs:
       if: ${{ inputs.t9n-add != 'false' }}
       run: |
         echo -e "\e[34mFormatting translations - Add"
-        if [[ ${NEWLINES} == "true" ]]; then FLAGS="--newlines "; fi
+        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales '${LOCALES}' "; fi
+        if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${ADD} != "" ]]; then FLAGS="${FLAGS}--add "; fi
 
         npx mfv format ${FLAGS}
       env:
+        LOCALES: ${{ inputs.t9n-locales }}
         NEWLINES: ${{ inputs.t9n-newlines }}
         ADD: ${{ inputs.t9n-add }}
       shell: bash
@@ -200,11 +207,13 @@ runs:
       if: ${{ inputs.t9n-remove != 'false' }}
       run: |
         echo -e "\e[34mFormatting translations - Remove"
-        if [[ ${NEWLINES} == "true" ]]; then FLAGS="--newlines "; fi
+        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales '${LOCALES}' "; fi
+        if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${REMOVE} != "" ]]; then FLAGS="${FLAGS}--remove "; fi
 
         npx mfv format ${FLAGS}
       env:
+        LOCALES: ${{ inputs.t9n-locales }}
         NEWLINES: ${{ inputs.t9n-newlines }}
         REMOVE: ${{ inputs.t9n-remove }}
       shell: bash
@@ -221,11 +230,13 @@ runs:
       if: ${{ inputs.t9n-dedupe != 'false' }}
       run: |
         echo -e "\e[34mFormatting translations - Dedupe"
-        if [[ ${NEWLINES} == "true" ]]; then FLAGS="--newlines "; fi
+        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales '${LOCALES}' "; fi
+        if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${DEDUPE} != "" ]]; then FLAGS="${FLAGS}--dedupe "; fi
 
         npx mfv format ${FLAGS}
       env:
+        LOCALES: ${{ inputs.t9n-locales }}
         NEWLINES: ${{ inputs.t9n-newlines }}
         DEDUPE: ${{ inputs.t9n-dedupe }}
       shell: bash
@@ -242,11 +253,13 @@ runs:
       if: ${{ inputs.t9n-trim != 'false' }}
       run: |
         echo -e "\e[34mFormatting translations - Trim"
-        if [[ ${NEWLINES} == "true" ]]; then FLAGS="--newlines "; fi
+        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales '${LOCALES}' "; fi
+        if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${TRIM} != "" ]]; then FLAGS="${FLAGS}--trim "; fi
 
         npx mfv format ${FLAGS}
       env:
+        LOCALES: ${{ inputs.t9n-locales }}
         NEWLINES: ${{ inputs.t9n-newlines }}
         TRIM: ${{ inputs.t9n-trim }}
       shell: bash
@@ -263,11 +276,13 @@ runs:
       if: ${{ inputs.t9n-quotes != 'false' }}
       run: |
         echo -e "\e[34mFormatting translations - Quotes"
-        if [[ ${NEWLINES} == "true" ]]; then FLAGS="--newlines "; fi
+        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales '${LOCALES}' "; fi
+        if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${QUOTES} != "false" ]]; then FLAGS="${FLAGS}--quotes ${QUOTES} "; fi
 
         npx mfv format ${FLAGS}
       env:
+        LOCALES: ${{ inputs.t9n-locales }}
         NEWLINES: ${{ inputs.t9n-newlines }}
         QUOTES: ${{ inputs.t9n-quotes }}
       shell: bash

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -159,6 +159,24 @@ runs:
         FORCE_COLOR: 3
         PREFIX: ${{ inputs.t9n-branch-prefix }}
 
+    - name: Format Translations - Essentials
+      if: ${{ inputs.t9n-newlines != 'false' }}
+      run: |
+        echo -e "\e[34mFormatting translations - Essentials"
+        if [[ "${LOCALES}" != "" ]]; then FLAGS="--locales ${LOCALES}"; fi
+
+        eval npx mfv format ${FLAGS}
+      env:
+        LOCALES: "'${{ inputs.t9n-locales }}'"
+      shell: bash
+    - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
+      id: commit-essentials
+      with:
+        original-sha: ${{ steps.run-info.outputs.original-sha }}
+        source-branch: ${{ steps.run-info.outputs.source-branch }}
+        t9n-branch: ${{ steps.run-info.outputs.t9n-branch }}
+        change-type: 'Essentials'
+
     - name: Format Translations - Newlines
       if: ${{ inputs.t9n-newlines != 'false' }}
       run: |

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -162,6 +162,7 @@ runs:
     - name: Format Translations - Newlines
       if: ${{ inputs.t9n-newlines != 'false' }}
       run: |
+        set -x  # Enable debugging
         echo -e "\e[34mFormatting translations - Newlines"
         if [[ ${LOCALES} != "" ]]; then FLAGS="--locales '${LOCALES}' "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -162,10 +162,9 @@ runs:
     - name: Format Translations - Newlines
       if: ${{ inputs.t9n-newlines != 'false' }}
       run: |
-        set -x  # Enable debugging
         echo -e "\e[34mFormatting translations - Newlines"
-        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales '${LOCALES}' "; fi
-        if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
+        if [[ "${LOCALES}" != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
+        if [[ "${NEWLINES}" == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
 
         npx mfv format ${FLAGS}
       env:
@@ -185,7 +184,7 @@ runs:
       if: ${{ inputs.t9n-add != 'false' }}
       run: |
         echo -e "\e[34mFormatting translations - Add"
-        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales '${LOCALES}' "; fi
+        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${ADD} != "" ]]; then FLAGS="${FLAGS}--add "; fi
 
@@ -208,7 +207,7 @@ runs:
       if: ${{ inputs.t9n-remove != 'false' }}
       run: |
         echo -e "\e[34mFormatting translations - Remove"
-        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales '${LOCALES}' "; fi
+        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${REMOVE} != "" ]]; then FLAGS="${FLAGS}--remove "; fi
 
@@ -231,7 +230,7 @@ runs:
       if: ${{ inputs.t9n-dedupe != 'false' }}
       run: |
         echo -e "\e[34mFormatting translations - Dedupe"
-        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales '${LOCALES}' "; fi
+        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${DEDUPE} != "" ]]; then FLAGS="${FLAGS}--dedupe "; fi
 
@@ -254,7 +253,7 @@ runs:
       if: ${{ inputs.t9n-trim != 'false' }}
       run: |
         echo -e "\e[34mFormatting translations - Trim"
-        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales '${LOCALES}' "; fi
+        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${TRIM} != "" ]]; then FLAGS="${FLAGS}--trim "; fi
 
@@ -276,8 +275,9 @@ runs:
     - name: Format Translations - Quotes
       if: ${{ inputs.t9n-quotes != 'false' }}
       run: |
+        set -x  # Enable debugging
         echo -e "\e[34mFormatting translations - Quotes"
-        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales '${LOCALES}' "; fi
+        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${QUOTES} != "false" ]]; then FLAGS="${FLAGS}--quotes ${QUOTES} "; fi
 

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -163,7 +163,7 @@ runs:
       if: ${{ inputs.t9n-newlines != 'false' }}
       run: |
         echo -e "\e[34mFormatting translations - Essentials"
-        if [[ "${LOCALES}" != "" ]]; then FLAGS="--locales ${LOCALES}"; fi
+        if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES}"; fi
 
         eval npx mfv format ${FLAGS}
       env:
@@ -203,7 +203,7 @@ runs:
       if: ${{ inputs.t9n-add != 'false' }}
       run: |
         echo -e "\e[34mFormatting translations - Add"
-        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
+        if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${ADD} != "" ]]; then FLAGS="${FLAGS}--add "; fi
 
@@ -226,7 +226,7 @@ runs:
       if: ${{ inputs.t9n-remove != 'false' }}
       run: |
         echo -e "\e[34mFormatting translations - Remove"
-        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
+        if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${REMOVE} != "" ]]; then FLAGS="${FLAGS}--remove "; fi
 
@@ -249,7 +249,7 @@ runs:
       if: ${{ inputs.t9n-dedupe != 'false' }}
       run: |
         echo -e "\e[34mFormatting translations - Dedupe"
-        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
+        if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${DEDUPE} != "" ]]; then FLAGS="${FLAGS}--dedupe "; fi
 
@@ -273,7 +273,7 @@ runs:
       run: |
         set -x  # Enable debugging
         echo -e "\e[34mFormatting translations - Trim"
-        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
+        if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${TRIM} != "" ]]; then FLAGS="${FLAGS}--trim "; fi
 
@@ -297,7 +297,7 @@ runs:
       run: |
         set -x  # Enable debugging
         echo -e "\e[34mFormatting translations - Quotes"
-        if [[ ${LOCALES} != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
+        if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${QUOTES} != "false" ]]; then FLAGS="${FLAGS}--quotes ${QUOTES} "; fi
 

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -3,19 +3,19 @@ description: Run translation formatting and open a PR with the changes as necess
 inputs:
   t9n-newlines:
     description: When formatting complex arguments, use newlines and indentation for readability
-    default: false
+    default: 'false'
   t9n-add:
     description: Add cases for missing supported plural and selectordinal categories
-    default: false
+    default: 'false'
   t9n-remove:
     description: Remove cases for unsupported plural and selectordinal categories
-    default: true
+    default: 'true'
   t9n-dedupe:
     description: Remove complex argument cases that duplicate the `other` case. Takes precedence over --add.
-    default: false
+    default: 'false'
   t9n-trim:
     description: Trim whitespace from both ends of messages
-    default: true
+    default: 'true'
   t9n-quotes:
     description: Replace quote characters with locale-appropriate characters ("source", "straight", or "both")
     default: 'straight'
@@ -25,7 +25,7 @@ inputs:
 
   draft-pr:
     description: Whether to open the translation formatting PR as a draft PR
-    default: true
+    default: 'true'
   github-token:
     description: Token used to cleanup branches and open the translation formatting PR
     required: true

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -167,7 +167,7 @@ runs:
         if [[ "${LOCALES}" != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ "${NEWLINES}" == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
 
-        npx mfv format ${FLAGS}
+        eval npx mfv format ${FLAGS}
       env:
         NEWLINES: ${{ inputs.t9n-newlines }}
         LOCALES: "'${{ inputs.t9n-locales }}'"
@@ -189,7 +189,7 @@ runs:
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${ADD} != "" ]]; then FLAGS="${FLAGS}--add "; fi
 
-        npx mfv format ${FLAGS}
+        eval npx mfv format ${FLAGS}
       env:
         LOCALES: "'${{ inputs.t9n-locales }}'"
         NEWLINES: ${{ inputs.t9n-newlines }}
@@ -212,7 +212,7 @@ runs:
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${REMOVE} != "" ]]; then FLAGS="${FLAGS}--remove "; fi
 
-        npx mfv format ${FLAGS}
+        eval npx mfv format ${FLAGS}
       env:
         LOCALES: "'${{ inputs.t9n-locales }}'"
         NEWLINES: ${{ inputs.t9n-newlines }}
@@ -235,7 +235,7 @@ runs:
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${DEDUPE} != "" ]]; then FLAGS="${FLAGS}--dedupe "; fi
 
-        npx mfv format ${FLAGS}
+        eval npx mfv format ${FLAGS}
       env:
         LOCALES: "'${{ inputs.t9n-locales }}'"
         NEWLINES: ${{ inputs.t9n-newlines }}
@@ -259,7 +259,7 @@ runs:
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${TRIM} != "" ]]; then FLAGS="${FLAGS}--trim "; fi
 
-        npx mfv format ${FLAGS}
+        eval npx mfv format ${FLAGS}
       env:
         LOCALES: "'${{ inputs.t9n-locales }}'"
         NEWLINES: ${{ inputs.t9n-newlines }}
@@ -283,7 +283,7 @@ runs:
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${QUOTES} != "false" ]]; then FLAGS="${FLAGS}--quotes ${QUOTES} "; fi
 
-        npx mfv format ${FLAGS}
+        eval npx mfv format ${FLAGS}
       env:
         LOCALES: "'${{ inputs.t9n-locales }}'"
         NEWLINES: ${{ inputs.t9n-newlines }}

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -180,7 +180,6 @@ runs:
     - name: Format Translations - Newlines
       if: ${{ inputs.t9n-newlines != 'false' }}
       run: |
-        set -x  # Enable debugging
         echo -e "\e[34mFormatting translations - Newlines"
         if [[ "${LOCALES}" != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ "${NEWLINES}" == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
@@ -271,7 +270,6 @@ runs:
     - name: Format Translations - Trim
       if: ${{ inputs.t9n-trim != 'false' }}
       run: |
-        set -x  # Enable debugging
         echo -e "\e[34mFormatting translations - Trim"
         if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
@@ -295,7 +293,6 @@ runs:
     - name: Format Translations - Quotes
       if: ${{ inputs.t9n-quotes != 'false' }}
       run: |
-        set -x  # Enable debugging
         echo -e "\e[34mFormatting translations - Quotes"
         if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -162,6 +162,7 @@ runs:
     - name: Format Translations - Newlines
       if: ${{ inputs.t9n-newlines != 'false' }}
       run: |
+        set -x  # Enable debugging
         echo -e "\e[34mFormatting translations - Newlines"
         if [[ "${LOCALES}" != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ "${NEWLINES}" == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
@@ -169,7 +170,7 @@ runs:
         npx mfv format ${FLAGS}
       env:
         NEWLINES: ${{ inputs.t9n-newlines }}
-        LOCALES: ${{ inputs.t9n-locales }}
+        LOCALES: "'${{ inputs.t9n-locales }}'"
       shell: bash
     - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
       if: ${{ inputs.t9n-newlines != 'false' }}
@@ -190,7 +191,7 @@ runs:
 
         npx mfv format ${FLAGS}
       env:
-        LOCALES: ${{ inputs.t9n-locales }}
+        LOCALES: "'${{ inputs.t9n-locales }}'"
         NEWLINES: ${{ inputs.t9n-newlines }}
         ADD: ${{ inputs.t9n-add }}
       shell: bash
@@ -213,7 +214,7 @@ runs:
 
         npx mfv format ${FLAGS}
       env:
-        LOCALES: ${{ inputs.t9n-locales }}
+        LOCALES: "'${{ inputs.t9n-locales }}'"
         NEWLINES: ${{ inputs.t9n-newlines }}
         REMOVE: ${{ inputs.t9n-remove }}
       shell: bash
@@ -236,7 +237,7 @@ runs:
 
         npx mfv format ${FLAGS}
       env:
-        LOCALES: ${{ inputs.t9n-locales }}
+        LOCALES: "'${{ inputs.t9n-locales }}'"
         NEWLINES: ${{ inputs.t9n-newlines }}
         DEDUPE: ${{ inputs.t9n-dedupe }}
       shell: bash
@@ -252,6 +253,7 @@ runs:
     - name: Format Translations - Trim
       if: ${{ inputs.t9n-trim != 'false' }}
       run: |
+        set -x  # Enable debugging
         echo -e "\e[34mFormatting translations - Trim"
         if [[ ${LOCALES} != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
@@ -259,7 +261,7 @@ runs:
 
         npx mfv format ${FLAGS}
       env:
-        LOCALES: ${{ inputs.t9n-locales }}
+        LOCALES: "'${{ inputs.t9n-locales }}'"
         NEWLINES: ${{ inputs.t9n-newlines }}
         TRIM: ${{ inputs.t9n-trim }}
       shell: bash
@@ -283,7 +285,7 @@ runs:
 
         npx mfv format ${FLAGS}
       env:
-        LOCALES: ${{ inputs.t9n-locales }}
+        LOCALES: "'${{ inputs.t9n-locales }}'"
         NEWLINES: ${{ inputs.t9n-newlines }}
         QUOTES: ${{ inputs.t9n-quotes }}
       shell: bash


### PR DESCRIPTION
Adds a `locales` flag so the action can be run with different options against different sets of locales. Most useful for separate source (`en`) options and potentially `en-gb` quoting.

`eval` is used to be forgiving of quotes in the `--locales` flag. If a consumer sends `locales: en, fr, ja`, we automatically wrap it with quotes so bash interprets it as a single string when we concatenate it into the `FLAGS`.

For example: `mfv format -l en, fr` fails, but injecting quotes alone gets us `mfv format -l '\'en, fr\''`, which also fails. `eval` turns it into `mfv format -l 'en, fr'` which is what we want.

Also adds the "essentials" step with no additional options to create a baseline commit.