### PR TITLE
Add additional inputs/flags

### DIFF
--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -189,6 +189,7 @@ runs:
     - name: Format Translations - Argument Correction
       if: ${{ inputs.t9n-correct != 'false' }}
       run: |
+        set -x
         echo -e "\e[34mFormatting translations - Argument Correction"
         if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${CORRECT} == "true" ]]; then FLAGS="${FLAGS} --correct "; fi

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -20,8 +20,17 @@ inputs:
     description: Replace quote characters with locale-appropriate characters ("source", "straight", or "both")
     default: 'straight'
   t9n-locales:
-    description: Comma-separated list of locales to format
+    description: Comma-separated list of locales to format. If empty, all locales are formatted.
     default: ''
+  t9n-source:
+    description: The locale to use as the source
+    default: ''
+  t9n-path:
+    description: Glob path to a directory containing locale files
+    default: ''
+  t9n-correct:
+    description: Attempt to correct argument names
+    default: 'true'
 
   draft-pr:
     description: Whether to open the translation formatting PR as a draft PR
@@ -177,17 +186,45 @@ runs:
         t9n-branch: ${{ steps.run-info.outputs.t9n-branch }}
         change-type: 'Essentials'
 
+    - name: Format Translations - Argument Correction
+      if: ${{ inputs.t9n-correct != 'false' }}
+      run: |
+        echo -e "\e[34mFormatting translations - Argument Correction"
+        if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
+        if [[ ${CORRECT} == "true" ]]; then FLAGS="${FLAGS} --correct"; fi
+        if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source ${SOURCE} "; fi
+        if [[ ${PATH} != "" ]]; then FLAGS="${FLAGS} --path ${PATH} "; fi
+
+        eval npx mfv format ${FLAGS}
+      env:
+        LOCALES: "'${{ inputs.t9n-locales }}'"
+        SOURCE: ${{ inputs.t9n-source }}
+        CORRECT: ${{ inputs.t9n-correct }}
+        PATH: ${{ inputs.t9n-path }}
+      shell: bash
+    - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
+      id: commit-argument-correction
+      with:
+        original-sha: ${{ steps.run-info.outputs.original-sha }}
+        source-branch: ${{ steps.run-info.outputs.source-branch }}
+        t9n-branch: ${{ steps.run-info.outputs.t9n-branch }}
+        change-type: 'Argument Correction'
+
     - name: Format Translations - Newlines
       if: ${{ inputs.t9n-newlines != 'false' }}
       run: |
         echo -e "\e[34mFormatting translations - Newlines"
         if [[ "${LOCALES}" != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ "${NEWLINES}" == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
+        if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source ${SOURCE} "; fi
+        if [[ ${PATH} != "" ]]; then FLAGS="${FLAGS} --path ${PATH} "; fi
 
         eval npx mfv format ${FLAGS}
       env:
         NEWLINES: ${{ inputs.t9n-newlines }}
         LOCALES: "'${{ inputs.t9n-locales }}'"
+        SOURCE: ${{ inputs.t9n-source }}
+        PATH: ${{ inputs.t9n-path }}
       shell: bash
     - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
       if: ${{ inputs.t9n-newlines != 'false' }}
@@ -205,12 +242,16 @@ runs:
         if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${ADD} != "" ]]; then FLAGS="${FLAGS}--add "; fi
+        if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source ${SOURCE} "; fi
+        if [[ ${PATH} != "" ]]; then FLAGS="${FLAGS} --path ${PATH} "; fi
 
         eval npx mfv format ${FLAGS}
       env:
         LOCALES: "'${{ inputs.t9n-locales }}'"
         NEWLINES: ${{ inputs.t9n-newlines }}
         ADD: ${{ inputs.t9n-add }}
+        SOURCE: ${{ inputs.t9n-source }}
+        PATH: ${{ inputs.t9n-path }}
       shell: bash
     - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
       if: ${{ inputs.t9n-add != 'false' }}
@@ -228,12 +269,16 @@ runs:
         if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${REMOVE} != "" ]]; then FLAGS="${FLAGS}--remove "; fi
+        if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source ${SOURCE} "; fi
+        if [[ ${PATH} != "" ]]; then FLAGS="${FLAGS} --path ${PATH} "; fi
 
         eval npx mfv format ${FLAGS}
       env:
         LOCALES: "'${{ inputs.t9n-locales }}'"
         NEWLINES: ${{ inputs.t9n-newlines }}
         REMOVE: ${{ inputs.t9n-remove }}
+        SOURCE: ${{ inputs.t9n-source }}
+        PATH: ${{ inputs.t9n-path }}
       shell: bash
     - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
       if: ${{ inputs.t9n-remove != 'false' }}
@@ -251,12 +296,16 @@ runs:
         if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${DEDUPE} != "" ]]; then FLAGS="${FLAGS}--dedupe "; fi
+        if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source ${SOURCE} "; fi
+        if [[ ${PATH} != "" ]]; then FLAGS="${FLAGS} --path ${PATH} "; fi
 
         eval npx mfv format ${FLAGS}
       env:
         LOCALES: "'${{ inputs.t9n-locales }}'"
         NEWLINES: ${{ inputs.t9n-newlines }}
         DEDUPE: ${{ inputs.t9n-dedupe }}
+        SOURCE: ${{ inputs.t9n-source }}
+        PATH: ${{ inputs.t9n-path }}
       shell: bash
     - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
       if: ${{ inputs.t9n-dedupe != 'false' }}
@@ -274,12 +323,16 @@ runs:
         if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${TRIM} != "" ]]; then FLAGS="${FLAGS}--trim "; fi
+        if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source ${SOURCE} "; fi
+        if [[ ${PATH} != "" ]]; then FLAGS="${FLAGS} --path ${PATH} "; fi
 
         eval npx mfv format ${FLAGS}
       env:
         LOCALES: "'${{ inputs.t9n-locales }}'"
         NEWLINES: ${{ inputs.t9n-newlines }}
         TRIM: ${{ inputs.t9n-trim }}
+        SOURCE: ${{ inputs.t9n-source }}
+        PATH: ${{ inputs.t9n-path }}
       shell: bash
     - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
       if: ${{ inputs.t9n-trim != 'false' }}
@@ -297,12 +350,16 @@ runs:
         if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${QUOTES} != "false" ]]; then FLAGS="${FLAGS}--quotes ${QUOTES} "; fi
+        if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source ${SOURCE} "; fi
+        if [[ ${PATH} != "" ]]; then FLAGS="${FLAGS} --path ${PATH} "; fi
 
         eval npx mfv format ${FLAGS}
       env:
         LOCALES: "'${{ inputs.t9n-locales }}'"
         NEWLINES: ${{ inputs.t9n-newlines }}
         QUOTES: ${{ inputs.t9n-quotes }}
+        SOURCE: ${{ inputs.t9n-source }}
+        PATH: ${{ inputs.t9n-path }}
       shell: bash
     - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
       if: ${{ inputs.t9n-quotes != 'false' }}

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -172,11 +172,15 @@ runs:
       if: ${{ inputs.t9n-newlines != 'false' }}
       run: |
         echo -e "\e[34mFormatting translations - Essentials"
-        if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES}"; fi
+        if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
+        if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source ${SOURCE} "; fi
+        if [[ ${LOCALES_PATH} != "" ]]; then FLAGS="${FLAGS} --path ${LOCALES_PATH}"; fi
 
         eval npx mfv format ${FLAGS}
       env:
         LOCALES: "'${{ inputs.t9n-locales }}'"
+        SOURCE: ${{ inputs.t9n-source }}
+        LOCALES_PATH: ${{ inputs.t9n-path }}
       shell: bash
     - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
       id: commit-essentials
@@ -189,7 +193,6 @@ runs:
     - name: Format Translations - Argument Correction
       if: ${{ inputs.t9n-correct != 'false' }}
       run: |
-        set -x
         echo -e "\e[34mFormatting translations - Argument Correction"
         if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${CORRECT} == "true" ]]; then FLAGS="${FLAGS} --correct "; fi

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -191,9 +191,9 @@ runs:
       run: |
         echo -e "\e[34mFormatting translations - Argument Correction"
         if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
-        if [[ ${CORRECT} == "true" ]]; then FLAGS="${FLAGS} --correct"; fi
+        if [[ ${CORRECT} == "true" ]]; then FLAGS="${FLAGS} --correct "; fi
         if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source ${SOURCE} "; fi
-        if [[ ${PATH} != "" ]]; then FLAGS="${FLAGS} --path ${PATH} "; fi
+        if [[ ${PATH} != "" ]]; then FLAGS="${FLAGS} --path ${PATH}"; fi
 
         eval npx mfv format ${FLAGS}
       env:

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -194,14 +194,14 @@ runs:
         if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${CORRECT} == "true" ]]; then FLAGS="${FLAGS} --correct "; fi
         if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source ${SOURCE} "; fi
-        if [[ ${PATH} != "" ]]; then FLAGS="${FLAGS} --path ${PATH}"; fi
+        if [[ ${LOCALES_PATH} != "" ]]; then FLAGS="${FLAGS} --path ${LOCALES_PATH}"; fi
 
         eval npx mfv format ${FLAGS}
       env:
         LOCALES: "'${{ inputs.t9n-locales }}'"
         SOURCE: ${{ inputs.t9n-source }}
         CORRECT: ${{ inputs.t9n-correct }}
-        PATH: ${{ inputs.t9n-path }}
+        LOCALES_PATH: ${{ inputs.t9n-path }}
       shell: bash
     - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
       id: commit-argument-correction
@@ -218,14 +218,14 @@ runs:
         if [[ "${LOCALES}" != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ "${NEWLINES}" == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source ${SOURCE} "; fi
-        if [[ ${PATH} != "" ]]; then FLAGS="${FLAGS} --path ${PATH} "; fi
+        if [[ ${LOCALES_PATH} != "" ]]; then FLAGS="${FLAGS} --path ${LOCALES_PATH} "; fi
 
         eval npx mfv format ${FLAGS}
       env:
         NEWLINES: ${{ inputs.t9n-newlines }}
         LOCALES: "'${{ inputs.t9n-locales }}'"
         SOURCE: ${{ inputs.t9n-source }}
-        PATH: ${{ inputs.t9n-path }}
+        LOCALES_PATH: ${{ inputs.t9n-path }}
       shell: bash
     - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
       if: ${{ inputs.t9n-newlines != 'false' }}
@@ -244,7 +244,7 @@ runs:
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${ADD} != "" ]]; then FLAGS="${FLAGS}--add "; fi
         if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source ${SOURCE} "; fi
-        if [[ ${PATH} != "" ]]; then FLAGS="${FLAGS} --path ${PATH} "; fi
+        if [[ ${LOCALES_PATH} != "" ]]; then FLAGS="${FLAGS} --path ${LOCALES_PATH} "; fi
 
         eval npx mfv format ${FLAGS}
       env:
@@ -252,7 +252,7 @@ runs:
         NEWLINES: ${{ inputs.t9n-newlines }}
         ADD: ${{ inputs.t9n-add }}
         SOURCE: ${{ inputs.t9n-source }}
-        PATH: ${{ inputs.t9n-path }}
+        LOCALES_PATH: ${{ inputs.t9n-path }}
       shell: bash
     - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
       if: ${{ inputs.t9n-add != 'false' }}
@@ -271,7 +271,7 @@ runs:
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${REMOVE} != "" ]]; then FLAGS="${FLAGS}--remove "; fi
         if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source ${SOURCE} "; fi
-        if [[ ${PATH} != "" ]]; then FLAGS="${FLAGS} --path ${PATH} "; fi
+        if [[ ${LOCALES_PATH} != "" ]]; then FLAGS="${FLAGS} --path ${LOCALES_PATH} "; fi
 
         eval npx mfv format ${FLAGS}
       env:
@@ -279,7 +279,7 @@ runs:
         NEWLINES: ${{ inputs.t9n-newlines }}
         REMOVE: ${{ inputs.t9n-remove }}
         SOURCE: ${{ inputs.t9n-source }}
-        PATH: ${{ inputs.t9n-path }}
+        LOCALES_PATH: ${{ inputs.t9n-path }}
       shell: bash
     - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
       if: ${{ inputs.t9n-remove != 'false' }}
@@ -298,7 +298,7 @@ runs:
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${DEDUPE} != "" ]]; then FLAGS="${FLAGS}--dedupe "; fi
         if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source ${SOURCE} "; fi
-        if [[ ${PATH} != "" ]]; then FLAGS="${FLAGS} --path ${PATH} "; fi
+        if [[ ${LOCALES_PATH} != "" ]]; then FLAGS="${FLAGS} --path ${LOCALES_PATH} "; fi
 
         eval npx mfv format ${FLAGS}
       env:
@@ -306,7 +306,7 @@ runs:
         NEWLINES: ${{ inputs.t9n-newlines }}
         DEDUPE: ${{ inputs.t9n-dedupe }}
         SOURCE: ${{ inputs.t9n-source }}
-        PATH: ${{ inputs.t9n-path }}
+        LOCALES_PATH: ${{ inputs.t9n-path }}
       shell: bash
     - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
       if: ${{ inputs.t9n-dedupe != 'false' }}
@@ -325,7 +325,7 @@ runs:
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${TRIM} != "" ]]; then FLAGS="${FLAGS}--trim "; fi
         if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source ${SOURCE} "; fi
-        if [[ ${PATH} != "" ]]; then FLAGS="${FLAGS} --path ${PATH} "; fi
+        if [[ ${LOCALES_PATH} != "" ]]; then FLAGS="${FLAGS} --path ${LOCALES_PATH} "; fi
 
         eval npx mfv format ${FLAGS}
       env:
@@ -333,7 +333,7 @@ runs:
         NEWLINES: ${{ inputs.t9n-newlines }}
         TRIM: ${{ inputs.t9n-trim }}
         SOURCE: ${{ inputs.t9n-source }}
-        PATH: ${{ inputs.t9n-path }}
+        LOCALES_PATH: ${{ inputs.t9n-path }}
       shell: bash
     - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
       if: ${{ inputs.t9n-trim != 'false' }}
@@ -352,7 +352,7 @@ runs:
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${QUOTES} != "false" ]]; then FLAGS="${FLAGS}--quotes ${QUOTES} "; fi
         if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source ${SOURCE} "; fi
-        if [[ ${PATH} != "" ]]; then FLAGS="${FLAGS} --path ${PATH} "; fi
+        if [[ ${LOCALES_PATH} != "" ]]; then FLAGS="${FLAGS} --path ${LOCALES_PATH} "; fi
 
         eval npx mfv format ${FLAGS}
       env:
@@ -360,7 +360,7 @@ runs:
         NEWLINES: ${{ inputs.t9n-newlines }}
         QUOTES: ${{ inputs.t9n-quotes }}
         SOURCE: ${{ inputs.t9n-source }}
-        PATH: ${{ inputs.t9n-path }}
+        LOCALES_PATH: ${{ inputs.t9n-path }}
       shell: bash
     - uses: BrightspaceUI/actions/t9n-format/commit-changes@main
       if: ${{ inputs.t9n-quotes != 'false' }}


### PR DESCRIPTION
Adds additional standard `mfv` inputs/flags for controlling the CLI, as well as a new `format --correct` flag that was split out from "Essentials" to now be optional ([example](https://github.com/Brightspace/manager-view-fra/pull/2889/commits/a07a0d0852c631a6e695a468aeb95f300f9a5ee5))