### PR TITLE
`t9n-format`: Fix newlines flag check

### DIFF
--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -219,7 +219,7 @@ runs:
       run: |
         echo -e "\e[34mFormatting translations - Newlines"
         if [[ "${LOCALES}" != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
-        if [[ "${NEWLINES}" == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
+        if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source-locale ${SOURCE} "; fi
         if [[ ${LOCALES_PATH} != "" ]]; then FLAGS="${FLAGS} --path ${LOCALES_PATH} "; fi
 


### PR DESCRIPTION
The `NEWLINES` variable was mistakenly quoted only in the "Newlines" step with some unrelated changes. This broke that step causing it to find no changes to commit, but since the subsequent steps also use the flag newlines were being incorrectly added and committed in the next step.