### PR TITLE
`t9n-format`: Fix locales flag check

### DIFF
--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -218,7 +218,7 @@ runs:
       if: ${{ inputs.t9n-newlines != 'false' }}
       run: |
         echo -e "\e[34mFormatting translations - Newlines"
-        if [[ "${LOCALES}" != "" ]]; then FLAGS="--locales ${LOCALES} "; fi
+        if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
         if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source-locale ${SOURCE} "; fi
         if [[ ${LOCALES_PATH} != "" ]]; then FLAGS="${FLAGS} --path ${LOCALES_PATH} "; fi


### PR DESCRIPTION
One of the `LOCALES` check was looking for an empty string properly, causing it to enable when there was no `t9n-locales` input declared, preventing `mfv` from discovering locales automatically.