### PR TITLE
GAUD-7792 - Remove release-branch-management note

### DIFF
--- a/incremental-release/README.md
+++ b/incremental-release/README.md
@@ -53,10 +53,6 @@ The release step will fail to write to `package.json` because of the org-level r
 
 [Learn how to set up the D2L_RELEASE_TOKEN...](../docs/release-token.md)
 
-## Maintenance Branches
-
-**TO NOTE:** Non-admins may need to use [release-branch-management](https://github.com/Brightspace/release-branch-management) to create maintenance branches (ex: `1.7.x`, `release/2.5.x`, etc.), due to current restrictions with ruleset functionality.
-
 ## NPM Package Deployment
 
 If you'd like the action to deploy your package to NPM, set the `NPM` option to `true`.

--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -133,8 +133,6 @@ Regular expressions are complicated, but this essentially means branch names sho
 * `1.15.x` for patch releases on top of the `1.15` release (after version `1.16` exists)
 * `2.x` for feature releases on top of the `2` release (after version `3` exists)
 
-**TO NOTE:** Non-admins may need to use [release-branch-management](https://github.com/Brightspace/release-branch-management) to create these maintenance branches, due to current restrictions with ruleset functionality.
-
 ## Auto-releasing when LMS version changes
 
 When the LMS version changes -- for example from `20.22.6` to `20.22.7` -- it can be desireable for your project to ignore semantic versioning rules and automatically do a minor release.


### PR DESCRIPTION
This is no longer required and creating release branches should "just work"!