### PR TITLE
`t9n-format`: Install `messageformat-validator` as the first step

### DIFF
--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -46,6 +46,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Installing messageformat-validator
+      run: |
+        echo "Installing messageformat-validator..."
+        npm install messageformat-validator@3.0.0-beta --no-save
+      shell: bash
+
     - name: Get Run Info
       id: run-info
       run: |

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: Installing messageformat-validator
       run: |
         echo "Installing messageformat-validator..."
-        npm install messageformat-validator@3.0.0-beta --no-save
+        npm install messageformat-validator@next --no-save
       shell: bash
 
     - name: Get Run Info


### PR DESCRIPTION
GAUD-7861

Adding an install step so that a `messageformat-validator` dependency is not required to use the action.