### PR TITLE
Disable translation PR if there is no overall change

### DIFF
--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -386,7 +386,7 @@ runs:
       env:
         FORCE_COLOR: 3
         FORMAT_CONFLICT: ${{ steps.commit-changes.outputs.conflict }}
-        FORMAT_DIFF: ${{ contains(steps.*.outputs.diff, 'true') }}
+        FORMAT_DIFF: ${{ !contains(steps.*.outputs.diff, 'false') && contains(steps.*.outputs.diff, 'true') }}
         T9N_BRANCH: ${{ steps.run-info.outputs.t9n-branch }}
       shell: bash
 
@@ -503,7 +503,7 @@ runs:
         FORCE_COLOR: 3
         DRAFT_PR: ${{ inputs.draft-pr }}
         FORMAT_CONFLICT: ${{ steps.commit-changes.outputs.conflict }}
-        FORMAT_DIFF: ${{ contains(steps.*.outputs.diff, 'true') }}
+        FORMAT_DIFF: ${{ !contains(steps.*.outputs.diff, 'false') && contains(steps.*.outputs.diff, 'true') }}
         PULL_REQUEST_NUM: ${{ github.event.number }}
         PULL_REQUEST_BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         SOURCE_BRANCH: ${{ steps.run-info.outputs.source-branch }}
@@ -554,7 +554,7 @@ runs:
       env:
         FORCE_COLOR: 3
         FORMAT_CONFLICT: ${{ steps.commit-changes.outputs.conflict }}
-        FORMAT_DIFF: ${{ contains(steps.*.outputs.diff, 'true') }}
+        FORMAT_DIFF: ${{ !contains(steps.*.outputs.diff, 'false') && contains(steps.*.outputs.diff, 'true') }}
         ORIGINAL_SHA: ${{ steps.run-info.outputs.original-sha }}
         PULL_REQUEST_NUM: ${{ steps.pull-request.outputs.num }}
         COMMIT_STATUS_NAME: ${{ steps.commit-status-name.outputs.result }}

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -374,6 +374,15 @@ runs:
         t9n-branch: ${{ steps.run-info.outputs.t9n-branch }}
         change-type: 'Quotes'
 
+    - name: Compare Base to Head
+      id: compare
+      run: |
+        if ! git diff --quiet ${ORIGINAL_SHA}; then
+          echo "diff=true" >> ${GITHUB_OUTPUT}
+        fi
+      env:
+        ORIGINAL_SHA: ${{ steps.run-info.outputs.original-sha }}
+
     - name: Close Pull Request (if necessary)
       run: |
         echo -e "\e[34mClosing Pull Request (if necessary)"
@@ -386,7 +395,7 @@ runs:
       env:
         FORCE_COLOR: 3
         FORMAT_CONFLICT: ${{ steps.commit-changes.outputs.conflict }}
-        FORMAT_DIFF: ${{ !contains(steps.*.outputs.diff, 'false') && contains(steps.*.outputs.diff, 'true') }}
+        FORMAT_DIFF: ${{ steps.compare.outputs.diff == 'true' }}
         T9N_BRANCH: ${{ steps.run-info.outputs.t9n-branch }}
       shell: bash
 
@@ -503,7 +512,7 @@ runs:
         FORCE_COLOR: 3
         DRAFT_PR: ${{ inputs.draft-pr }}
         FORMAT_CONFLICT: ${{ steps.commit-changes.outputs.conflict }}
-        FORMAT_DIFF: ${{ !contains(steps.*.outputs.diff, 'false') && contains(steps.*.outputs.diff, 'true') }}
+        FORMAT_DIFF: ${{ steps.compare.outputs.diff == 'true' }}
         PULL_REQUEST_NUM: ${{ github.event.number }}
         PULL_REQUEST_BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         SOURCE_BRANCH: ${{ steps.run-info.outputs.source-branch }}
@@ -554,7 +563,7 @@ runs:
       env:
         FORCE_COLOR: 3
         FORMAT_CONFLICT: ${{ steps.commit-changes.outputs.conflict }}
-        FORMAT_DIFF: ${{ !contains(steps.*.outputs.diff, 'false') && contains(steps.*.outputs.diff, 'true') }}
+        FORMAT_DIFF: ${{ steps.compare.outputs.diff == 'true' }}
         ORIGINAL_SHA: ${{ steps.run-info.outputs.original-sha }}
         PULL_REQUEST_NUM: ${{ steps.pull-request.outputs.num }}
         COMMIT_STATUS_NAME: ${{ steps.commit-status-name.outputs.result }}

--- a/t9n-format/commit-changes/action.yml
+++ b/t9n-format/commit-changes/action.yml
@@ -27,6 +27,8 @@ runs:
 
       if ! git diff --quiet ${ORIGINAL_SHA}; then
         echo "diff=true" >> ${GITHUB_OUTPUT}
+      else
+        echo "diff=false" >> ${GITHUB_OUTPUT}
       fi
 
       echo -e "\n\e[34mCreating the Translation Branch"

--- a/t9n-format/commit-changes/action.yml
+++ b/t9n-format/commit-changes/action.yml
@@ -25,12 +25,6 @@ runs:
       fi
       echo -e "\e[31mChanges made - committing"
 
-      if ! git diff --quiet ${ORIGINAL_SHA}; then
-        echo "diff=true" >> ${GITHUB_OUTPUT}
-      else
-        echo "diff=false" >> ${GITHUB_OUTPUT}
-      fi
-
       echo -e "\n\e[34mCreating the Translation Branch"
       git stash --include-untracked
       git fetch origin +refs/heads/${SOURCE_BRANCH}:refs/heads/${SOURCE_BRANCH} -q -u || true


### PR DESCRIPTION
[GAUD-8129](https://desire2learn.atlassian.net/browse/GAUD-8129): Test `core` with newlines and trim, export in TIE

The `t9n-format` action can make multiple commits before opening a PR. Currently at each commit step it checks if there are any changes. If there are, it enables a flag to open the PR at the end. However, if the commits end up canceling each other out, then no PR should be opened.

This shouldn't actually happen in practice. There's a separate bug that's causing it I'll fix after this, but this seems like a good change to make anyway.

[GAUD-8129]: https://desire2learn.atlassian.net/browse/GAUD-8129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ