### PR TITLE
`t9n-format`: Fix compare step bad ref

### DIFF
--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -382,11 +382,13 @@ runs:
     - name: Compare Base to Head
       id: compare
       run: |
+        git fetch origin +refs/heads/${SOURCE_BRANCH}:refs/heads/${SOURCE_BRANCH} -q -u || true
         if ! git diff --quiet ${ORIGINAL_SHA}; then
-          echo "diff=true" >> ${GITHUB_OUTPUT}
+          echo "diff=true" >> ${GITHUB_OUTPUT};
         fi
       env:
         ORIGINAL_SHA: ${{ steps.run-info.outputs.original-sha }}
+        SOURCE_BRANCH: ${{ steps.run-info.outputs.source-branch }}
       shell: bash
 
     - name: Close Pull Request (if necessary)


### PR DESCRIPTION
[GAUD-8129](https://desire2learn.atlassian.net/browse/GAUD-8129): Test `core` with newlines and trim, export in TIE

Precisely because there are not changes, nothing was ever committed, and so the source branch was never fetched. That means the `ORIGINAL_SHA` ref doesn't exist (because the original checkout is working in detached head mode and has pruned it).

So, fetch the branch!