### PR TITLE
`t9n-format`: Compare SHAs instead of diffing

### DIFF
--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -68,7 +68,6 @@ runs:
         echo "source-branch=${SOURCE_BRANCH}" >> ${GITHUB_OUTPUT}
         echo "t9n-branch=${T9N_BRANCH}" >> ${GITHUB_OUTPUT}
         echo "original-sha=${ORIGINAL_SHA}" >> ${GITHUB_OUTPUT}
-        echo -e "$(git rev-list --count head) commits"
       env:
         FORCE_COLOR: 3
         PREFIX: ${{ inputs.t9n-branch-prefix }}
@@ -383,9 +382,8 @@ runs:
     - name: Compare Base to Head
       id: compare
       run: |
-        git commit --allow-empty
-        echo -e "$(git rev-list --count head) commits"
         git fetch origin +refs/heads/${SOURCE_BRANCH}:refs/heads/${SOURCE_BRANCH} -q -u || true
+        git diff --quiet ${ORIGINAL_SHA}
         if ! git diff --quiet ${ORIGINAL_SHA}; then
           echo "diff=true" >> ${GITHUB_OUTPUT};
           echo -e "Changes detected"

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -68,6 +68,7 @@ runs:
         echo "source-branch=${SOURCE_BRANCH}" >> ${GITHUB_OUTPUT}
         echo "t9n-branch=${T9N_BRANCH}" >> ${GITHUB_OUTPUT}
         echo "original-sha=${ORIGINAL_SHA}" >> ${GITHUB_OUTPUT}
+        echo "checkout-sha=$(git rev-parse HEAD)" >> ${GITHUB_OUTPUT}
       env:
         FORCE_COLOR: 3
         PREFIX: ${{ inputs.t9n-branch-prefix }}
@@ -382,15 +383,12 @@ runs:
     - name: Compare Base to Head
       id: compare
       run: |
-        git fetch origin +refs/heads/${SOURCE_BRANCH}:refs/heads/${SOURCE_BRANCH} -q -u || true
-        git diff --quiet ${ORIGINAL_SHA}
-        if ! git diff --quiet ${ORIGINAL_SHA}; then
+        if [ $(git rev-parse HEAD) != ${CHECKOUT_SHA} ]; then
           echo "diff=true" >> ${GITHUB_OUTPUT};
           echo -e "Changes detected"
         fi
       env:
-        ORIGINAL_SHA: ${{ steps.run-info.outputs.original-sha }}
-        SOURCE_BRANCH: ${{ steps.run-info.outputs.source-branch }}
+        CHECKOUT_SHA: ${{ steps.run-info.outputs.checkout-sha }}
       shell: bash
 
     - name: Close Pull Request (if necessary)

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -385,7 +385,7 @@ runs:
       run: |
         if ! git diff --quiet ${CHECKOUT_SHA} HEAD; then
           echo "diff=true" >> ${GITHUB_OUTPUT};
-          echo -e "Changes detected"
+          echo -e "Overall changes detected"
         fi
       env:
         CHECKOUT_SHA: ${{ steps.run-info.outputs.checkout-sha }}

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -68,6 +68,7 @@ runs:
         echo "source-branch=${SOURCE_BRANCH}" >> ${GITHUB_OUTPUT}
         echo "t9n-branch=${T9N_BRANCH}" >> ${GITHUB_OUTPUT}
         echo "original-sha=${ORIGINAL_SHA}" >> ${GITHUB_OUTPUT}
+        echo -e "$(git rev-list --count head) commits"
       env:
         FORCE_COLOR: 3
         PREFIX: ${{ inputs.t9n-branch-prefix }}
@@ -382,9 +383,12 @@ runs:
     - name: Compare Base to Head
       id: compare
       run: |
+        git commit --allow-empty
+        echo -e "$(git rev-list --count head) commits"
         git fetch origin +refs/heads/${SOURCE_BRANCH}:refs/heads/${SOURCE_BRANCH} -q -u || true
         if ! git diff --quiet ${ORIGINAL_SHA}; then
           echo "diff=true" >> ${GITHUB_OUTPUT};
+          echo -e "Changes detected"
         fi
       env:
         ORIGINAL_SHA: ${{ steps.run-info.outputs.original-sha }}

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -383,7 +383,7 @@ runs:
     - name: Compare Base to Head
       id: compare
       run: |
-        if [ $(git rev-parse HEAD) != ${CHECKOUT_SHA} ]; then
+        if ! git diff ${CHECKOUT_SHA} HEAD; then
           echo "diff=true" >> ${GITHUB_OUTPUT};
           echo -e "Changes detected"
         fi

--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -383,7 +383,7 @@ runs:
     - name: Compare Base to Head
       id: compare
       run: |
-        if ! git diff ${CHECKOUT_SHA} HEAD; then
+        if ! git diff --quiet ${CHECKOUT_SHA} HEAD; then
           echo "diff=true" >> ${GITHUB_OUTPUT};
           echo -e "Changes detected"
         fi


### PR DESCRIPTION
[GAUD-8129](https://desire2learn.atlassian.net/browse/GAUD-8129): Test core with newlines and trim, export in TIE

For whatever reason, fetching the branch and `diff`ing was not giving consistent results (sometimes just erroring out). I'm not sure why, but this seems cleaner anyway. We just store the SHA after checkout (before any commits), then `diff` against that before trying to open the PR.

This is purely for inter-action comparison anyway. Other checks for conflicts and base branch updates are in place elsewhere (though maybe broken at the moment 😅).

[GAUD-8129]: https://desire2learn.atlassian.net/browse/GAUD-8129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ