### PR TITLE
Remove newlines from trim

### DIFF
--- a/t9n-format/action.yml
+++ b/t9n-format/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: When formatting complex arguments, use newlines and indentation for readability
     default: 'false'
   t9n-add:
-    description: Add cases for missing supported plural and selectordinal categories
+    description: Add cases for supported but missing plural and selectordinal categories
     default: 'false'
   t9n-remove:
     description: Remove cases for unsupported plural and selectordinal categories
@@ -232,7 +232,6 @@ runs:
       run: |
         echo -e "\e[34mFormatting translations - Trim"
         if [[ "${LOCALES}" != "''" ]]; then FLAGS="--locales ${LOCALES} "; fi
-        if [[ ${NEWLINES} == "true" ]]; then FLAGS="${FLAGS}--newlines "; fi
         if [[ ${TRIM} != "" ]]; then FLAGS="${FLAGS}--trim "; fi
         if [[ ${SOURCE} != "" ]]; then FLAGS="${FLAGS} --source-locale ${SOURCE} "; fi
         if [[ ${LOCALES_PATH} != "" ]]; then FLAGS="${FLAGS} --path ${LOCALES_PATH} "; fi


### PR DESCRIPTION
[GAUD-8227](https://desire2learn.atlassian.net/browse/GAUD-8227): Remove `newlines` option from `trim` step

When "Trim" was moved above "Newlines", it should have stopped adding the `--newlines` option. With it, both changes are being done in "Trim".

Also sync the `add` description between inputs and docs.

[GAUD-8227]: https://desire2learn.atlassian.net/browse/GAUD-8227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ