### PR TITLE
GAUD-7842 - Output new PR num for vdiff when opened

### DIFF
--- a/vdiff/README.md
+++ b/vdiff/README.md
@@ -57,6 +57,9 @@ General Inputs:
 
 See the [`@brightspace-ui/testing` repo's README](https://github.com/BrightspaceUI/testing#running-tests) to learn more about these flags.
 
+Outputs:
+* `pr-num`: ID number of the newly opened vdiff goldens pull request. Only sent for the run where the PR is first opened.
+
 **Notes:**
 * You can also run this action in the release workflow to confirm the `main` branch is in a good state before releasing.  If there's a problem, a PR will be opened against `main` to get the goldens back in the expected state.  This mostly comes down to a time versus risk trade-off - the risk of things getting out of sync may be lower than the time taken to run the vdiff tests every release.
 * You can use the standard `GITHUB_TOKEN` that exists automatically, but will need to [set up the AWS secrets](#setting-up-aws-access-creds).

--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -34,6 +34,10 @@ inputs:
   vdiff-branch-prefix:
     description: Prefix for vdiff branches
     default: 'ghworkflow/vdiff'
+outputs:
+  pr-num:
+    description: ID number of vdiff goldens PR (only sent when first opened)
+    value: ${{ steps.pull-request.outputs.new }}
 runs:
   using: composite
   steps:
@@ -466,6 +470,7 @@ runs:
             });
             goldenPrNum = newPR.data.number;
             console.log(`PR #${goldenPrNum} opened: ${newPR.data.html_url}`);
+            core.setOutput('new', goldenPrNum);
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
I'm working on the goldens update process for the `testing` repo, and it will make things cleaner if I'm given this PR number (rather than having to query for it after the fact).