### PR TITLE
GAUD-664 - Update semantic-release to v25

### DIFF
--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -6,6 +6,8 @@ This GitHub action uses the [semantic-release](https://semantic-release.gitbook.
 * A GitHub Release will be created
 * Optionally, the package will be published to NPM
 
+Note: Our `semantic-release` version requires at least Node `v22.14.0` or `v24.10.0`.
+
 ## Using the Action
 
 Typically this action is triggered from a workflow that runs on your `main` branch after each commit or pull request merge.

--- a/semantic-release/action.yml
+++ b/semantic-release/action.yml
@@ -34,7 +34,7 @@ runs:
     - name: Installing semantic-release
       run: |
         echo "Installing semantic-release..."
-        npm install semantic-release@23 @semantic-release/git@10 --no-save
+        npm install semantic-release@25 @semantic-release/git@10 --no-save
       shell: bash
     - name: Get maintenance version
       uses: BrightspaceUI/actions/get-maintenance-version@main


### PR DESCRIPTION
Continuation of https://github.com/BrightspaceUI/actions/pull/208 and https://github.com/BrightspaceUI/actions/pull/209.

This is the final PR to get us to the latest `semantic-release` version. 15 repos were using node 20 and needed to be updated. I went to node 24 where I could, otherwise they were bumped to node 22.

Breaking Changes:

- [v24](https://github.com/semantic-release/semantic-release/releases/tag/v24.0.0)
  - The `commit-analyzer` and `release-notes-generator` plugins now expect to be used with the latest major versions of
`conventional-changelog` packages (which we don't use)
- [v25](https://github.com/semantic-release/semantic-release/releases/tag/v25.0.0):
  - Minimum of node 22.14 is required, dropping support for node 20, 21 and 23 
  - Minimum node version for the v24 range is now v24.10.0
