### PR TITLE
update token env var in incremental-release

### DIFF
--- a/incremental-release/action.yml
+++ b/incremental-release/action.yml
@@ -98,5 +98,5 @@ runs:
         echo "Running npm publish with options: ${OPTS}"
         npm publish ${OPTS}
       env:
-        NODE_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}
+        NPM_TOKEN: ${{ inputs.NPM_TOKEN }}
       shell: bash


### PR DESCRIPTION
If I'm not mistaken, [semantic-release uses the environment variable `NPM_AUTH`][1]. This is used [here][2], but not in incremental-release.

`NODE_AUTH_TOKEN` is [specific to `actions/setup-node`][3].

I saw related errors when updating Brightspace/setup-node usage:
- https://github.com/Brightspace/d2l-hypermedia-constants/actions/runs/27161074713/job/80176367171
- https://github.com/BrightspaceHypermediaComponents/siren-sdk/actions/runs/27215186281/job/80354746280

Not sure how they ever succeeded...
Hopefully this can fix the errors I saw.

[1]: https://github.com/semantic-release/semantic-release/blob/master/docs/usage/ci-configuration.md#authentication-for-plugins
[2]: https://github.com/BrightspaceUI/actions/blob/5869a3b2ae349f0b5fa466fa385ecf5b1f3256e1/semantic-release/action.yml#L81
[3]: https://github.com/actions/setup-node/blob/0355742c943ddb13ca8a6b700f824231caa91e75/src/authutil.ts#L44

[HOD-4564 - Proxy Registry > Mass update repos](https://desire2learn.atlassian.net/browse/HOD-4564)