### PR TITLE
GAUD-10137: pin semantic release

### DIFF
--- a/semantic-release/action.yml
+++ b/semantic-release/action.yml
@@ -34,7 +34,7 @@ runs:
     - name: Installing semantic-release
       run: |
         echo "Installing semantic-release..."
-        npm install semantic-release@25 @semantic-release/git@10 --no-save
+        npm install semantic-release@25.0.3 @semantic-release/git@10 --no-save
       shell: bash
     - name: Get maintenance version
       uses: BrightspaceUI/actions/get-maintenance-version@main


### PR DESCRIPTION
Semantic release appears to have accidentally published their "next" version as a patch (oh, the irony). Example of a failing release run because of it:
https://github.com/BrightspaceHypermediaComponents/users/actions/runs/27296558905/job/80630676894

I think [they released this feature branch](https://github.com/semantic-release/semantic-release/compare/master...feat/core-integration).