### PR TITLE
update-package-lock: default NODE_AUTH_TOKEN to existing env var

### DIFF
--- a/update-package-lock/action.yml
+++ b/update-package-lock/action.yml
@@ -89,7 +89,7 @@ runs:
           rm package-lock.json
           npm install
         env:
-          NODE_AUTH_TOKEN: ${{ inputs.NODE_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ inputs.NODE_AUTH_TOKEN || env.NODE_AUTH_TOKEN }}
         shell: bash
       - name: Check For Changes
         id: check-for-changes
@@ -123,7 +123,7 @@ runs:
           npm ls --json --package-lock-only --all > "$RUNNER_TEMP/dependencies-after.json"
         env:
           GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ inputs.NODE_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ inputs.NODE_AUTH_TOKEN || env.NODE_AUTH_TOKEN }}
         shell: bash
       - name: Create PR (if necessary)
         id: create-pr


### PR DESCRIPTION
When `setup-node` is used with `registry-url` and `NODE_AUTH_TOKEN`
e.g.
```yaml
uses: setup-node
with:
  registry-url: example.com
env:
  NODE_AUTH_TOKEN: ${{ secrets.REGISTRY_TOKEN }}
```

`setup-node` also [sets the `NODE_AUTH_TOKEN` env var][1] for all following steps, where there should be no need to set `NODE_AUTH_TOKEN` explicitly again.

Therefore, actions that utilize `NODE_AUTH_TOKEN` would be best _not_ to override this env var unnecessarily.

This change could prevent errors like [this][2], which was caused by `NODE_AUTH_TOKEN` being overridden with the default empty value. It should also make migration to the proxy registry easier with fewer changes needed.

[1]: https://github.com/actions/setup-node/blob/f4a67bbeca970f103397d3d2b9462cf787cd2980/src/authutil.ts#L51
[2]: https://d2l.slack.com/archives/C0B4YTRKG4B/p1779909251835829

[HOD-4564 - Proxy Registry > Mass update repos](https://desire2learn.atlassian.net/browse/HOD-4564)