### PR TITLE
GAUD-8818 - Remove ability to publish to public npm with incremental-release

### DIFF
--- a/incremental-release/README.md
+++ b/incremental-release/README.md
@@ -39,7 +39,6 @@ Options:
 * `DRY_RUN` (default: `false`): Simulates a release but does not actually do one
 * `GITHUB_TOKEN`: Token to use to update version in 'package.json' and create the tag -- see section below on the release token for more details
 * `NPM` (default: `false`): Whether or not to release as an NPM package (see "NPM Package Deployment" below for more info)
-* `NPM_TOKEN` (optional if `NPM` is `false` or publishing to CodeArtifact): Token to publish to NPM (see "NPM Package Deployment" below for more info)
 
 Outputs:
 * `VERSION`: will contain the new version number if a release occurred, empty otherwise
@@ -55,7 +54,7 @@ The release step will fail to write to `package.json` because of the org-level r
 
 ## NPM Package Deployment
 
-If you'd like the action to deploy your package to NPM, set the `NPM` option to `true`.
+If you'd like the action to deploy your package to CodeArtifact, set the `NPM` option to `true`.
 
 NPM deployments for maintenance branches (ex: `release/2022.2.x`, `1.7.x`, or `1.x`) will be annotated with a tag corresponding to the branch version (ex: `release-2022.2.x`, `release-1.7.x`, or `release-1.x`). All other deployments will use NPM's default tag of `latest`.
 
@@ -75,40 +74,6 @@ To publish to CodeArtifact, ensure that prior to running the `incremental-releas
   with:
     auth-token: ${{env.CODEARTIFACT_AUTH_TOKEN}}
 ```
-
-### NPM
-
-Setup Node:
-
-```yml
-- name: Setup Node
-  uses: Brightspace/setup-node@main
-  with:
-    registry-url: "https://registry.npmjs.org"
-```
-
-Then pass through the `NPM_TOKEN` secret.
-
-```yml
-- name: Incremental Release
-  uses: BrightspaceUI/actions/incremental-release@main
-  with:
-    GITHUB_TOKEN: ${{ secrets.D2L_RELEASE_TOKEN }}
-    NPM: true
-    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-```
-
-`NPM_TOKEN` is available as a shared organization secret in the `Brightspace`, `BrightspaceUI`, `BrightspaceUILabs` and `BrightspaceHypermediaComponents` organizations.
-
-If your package is being published under the `@brightspace-ui` or `@brightspace-ui-labs` NPM organizations, ensure that it has the proper configuration in its `package.json`:
-
-```json
-"publishConfig": {
-  "access": "public"
-}
-```
-
-Also ensure that `"private": true` is not present.
 
 ## Triggering a Release
 

--- a/incremental-release/action.yml
+++ b/incremental-release/action.yml
@@ -14,9 +14,6 @@ inputs:
     description: Whether or not to release as an NPM package
     default: false
     required: false
-  NPM_TOKEN:
-    description: Token to publish to NPM
-    required: false
 outputs:
   VERSION:
     description: Version of the new release
@@ -97,6 +94,4 @@ runs:
         [ ${{ steps.get-maintenance-version.outputs.IS_MAINTENANCE_BRANCH }} == true ] && OPTS="${OPTS} --tag release-${{ steps.get-maintenance-version.outputs.MAINTENANCE_VERSION }}"
         echo "Running npm publish with options: ${OPTS}"
         npm publish ${OPTS}
-      env:
-        NODE_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}
       shell: bash


### PR DESCRIPTION
The two repos using this feature (`d2l-hypermedia-constants` and `siren-sdk`)  have been migrated to `semantic-release`, and all other `incremental-release` users setting `NPM_TOKEN` unnecessarily have been cleaned up.