### PR TITLE
GAUD-10223 - Bump @octokit/graphql and @actions/core to latest versions

### DIFF
--- a/update-package-lock/action.yml
+++ b/update-package-lock/action.yml
@@ -67,7 +67,7 @@ runs:
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         run: |
           echo -e "\e[34mInstalling Dependencies"
-          npm install chalk@5 @octokit/graphql@4 @actions/core@1 --prefix ${{ github.action_path }} --no-save --loglevel error
+          npm install chalk@5 @octokit/graphql@9 @actions/core@3 --prefix ${{ github.action_path }} --no-save --loglevel error
         shell: bash
       - name: Checkout Branch
         if: ${{ steps.kill-switch.outputs.value != 'true' }}


### PR DESCRIPTION
Ok, I've tested this in both `copy-role` and `brightspace-integration` and the `HttpError: Invalid response body while trying to fetch https://api.github.com/graphql: Premature close` is gone!

The BSI run from 30 minutes ago failed without it, and I just triggered a `users` run that [failed](https://github.com/BrightspaceHypermediaComponents/users/actions/runs/28049057495), so I don't _think_ it's a coincidence. Is a good update to do regardless.

Most of the breaking changes are node version drops - I still need to verify all consumers are on at least node 20 before merging this.