### PR TITLE
GAUD-10297 - Fix vdiff for Dependabot PRs with non-read-only tokens

### DIFF
--- a/vdiff/action.yml
+++ b/vdiff/action.yml
@@ -517,10 +517,6 @@ runs:
         github-token: ${{ inputs.github-token }}
         script: |
           console.log('\x1b[34mUpdating Commit Status');
-          if (context.actor === 'dependabot[bot]') {
-            console.log('\x1b[33mActor is dependabot - skipping custom commit status update.');
-            return;
-          }
 
           let state, description, targetUrl;
           if (process.env.TESTS_PASSED === 'true' && process.env.FILES_MATCH === 'true') {
@@ -553,15 +549,19 @@ runs:
             core.setFailed('Completed - Build Failed.');
           }
 
-          await github.rest.repos.createCommitStatus({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            sha: process.env.ORIGINAL_SHA,
-            state: state,
-            target_url: targetUrl,
-            description: description,
-            context: process.env.COMMIT_STATUS_NAME
-          });
+          if (context.actor === 'dependabot[bot]') {
+            console.log('\x1b[33mActor is dependabot - skipping custom commit status update.');
+          } else {
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.ORIGINAL_SHA,
+              state: state,
+              target_url: targetUrl,
+              description: description,
+              context: process.env.COMMIT_STATUS_NAME
+            });
+          }
       env:
         FORCE_COLOR: 3
         GOLDENS_EMPTY: ${{ steps.commit-goldens.outputs.empty }}


### PR DESCRIPTION
So this is a fun one - discovered this talking to @GZolla, who said Mango mentioned their Dependabot PR was merged because CI was all green, but a vdiff PR was put up. Turns out, if the actor is Dependabot we were exiting early, before marking the build as failed. Looks like this bug has been here for [three years](https://github.com/BrightspaceUI/actions/pull/132), but I don't think this has come up because:
- If Dependabot has read-only permissions, it fails sooner (this is how most of our repos are set up)
- Most of the package updates that cause vdiff failures aren't handled by Dependabot

But still 😬 