### PR TITLE
BUC-7532: Setup configuration to allow prereleases

### DIFF
--- a/semantic-release/README.md
+++ b/semantic-release/README.md
@@ -47,6 +47,7 @@ Options:
 * `DEFAULT_BRANCH` (default: `"main"`): name of the default release branch
 * `DRY_RUN` (default: `false`): Runs semantic-release with the `--dry-run` flag to simulate a release but not actually do one
 * `GITHUB_TOKEN`: Token to use to update version in 'package.json' and create GitHub release -- see section below on the release token for more details
+* `GITHUB_PRERELEASE` (default: `false`): Whether to create the GitHub Release as a pre-release while preserving normal semantic-release versioning for the release branch (see "GitHub Pre-releases" below)
 * `MINOR_RELEASE_WITH_LMS` (default: `false`): Automatically perform a minor release whenever the LMS release changes (requires `aws-access-key-id`, `aws-secret-access-key` and `aws-session-token` to be passed)
 * `NPM` (default: `false`): Whether or not to release as an NPM package (see "NPM Package Deployment" below for more info)
 * `NPM_TOKEN` (optional if `NPM` is `false` or publishing to CodeArtifact): Token to publish to NPM (see "NPM Package Deployment" below for more info)
@@ -64,6 +65,39 @@ Notes:
 The release step will fail to write to `package.json` because of the org-level rule requiring pull requests, as well as any rulesets you may have defined requiring PRs or status checks to pass. To get around this, we use a special rotating `D2L_RELEASE_TOKEN`.
 
 [Learn how to set up the D2L_RELEASE_TOKEN...](../docs/release-token.md)
+
+## GitHub Pre-releases
+
+By default, the action creates a normal GitHub Release. Set `GITHUB_PRERELEASE` to `true` to create the GitHub Release as a pre-release instead.
+
+```yml
+- name: Semantic Release
+  uses: BrightspaceUI/actions/semantic-release@main
+  with:
+    DEFAULT_BRANCH: master
+    GITHUB_TOKEN: ${{ secrets.D2L_RELEASE_TOKEN }}
+    GITHUB_PRERELEASE: true
+```
+
+This option only changes the GitHub Release's pre-release status. The release branch remains a normal semantic-release branch, so semantic-release continues to create normal versions and tags such as `1.2.3` and `v1.2.3`, rather than prerelease versions such as `1.2.3-master.1`.
+
+This is useful for services that deploy a GitHub pre-release to a non-production environment and promote the same release to production later. A workflow can listen for the following GitHub Release events:
+
+```yml
+# Deploy to a non-production environment when the pre-release is created.
+on:
+  release:
+    types: [ prereleased ]
+```
+
+```yml
+# Deploy to production when the pre-release is promoted in GitHub.
+on:
+  release:
+    types: [ released ]
+```
+
+To promote a release, open the release in GitHub, edit it, clear the **Set as a pre-release** checkbox, and publish the change. GitHub emits the `released` event for the promoted release.
 
 ## NPM Package Deployment
 

--- a/semantic-release/action.yml
+++ b/semantic-release/action.yml
@@ -16,6 +16,9 @@ inputs:
   GITHUB_TOKEN:
     description: Token to use to update version in 'package.json' and create GitHub release
     required: true
+  GITHUB_PRERELEASE:
+    description: Whether or not to create a GitHub prerelease
+    default: false
   MINOR_RELEASE_WITH_LMS:
     description: Automatically perform a minor release whenever the LMS release changes
     default: false
@@ -67,12 +70,14 @@ runs:
       shell: bash
     - name: Create semantic-release configuration
       run: |
-        echo "Creating semantic-release configuration (DEFAULT_BRANCH: ${{ inputs.DEFAULT_BRANCH }} , NPM: ${{ inputs.NPM }})..."
+        echo "Creating semantic-release configuration (DEFAULT_BRANCH: ${{ inputs.DEFAULT_BRANCH }}, NPM: ${{ inputs.NPM }}, GITHUB_PRERELEASE: ${{ inputs.GITHUB_PRERELEASE }})..."
         ${{ github.action_path }}/create-config.sh
       env:
         DEFAULT_BRANCH: ${{ inputs.DEFAULT_BRANCH }}
         FILE_PATH: ${{ github.workspace }}/.releaserc.json
         NPM: ${{ inputs.NPM }}
+        GITHUB_PRERELEASE: ${{ inputs.GITHUB_PRERELEASE }}
+        GITHUB_PRERELEASE_PLUGIN_PATH: ${{ github.action_path }}/github-prerelease.js
       shell: bash
     - name: Running semantic-release
       id: semantic-release

--- a/semantic-release/create-config.sh
+++ b/semantic-release/create-config.sh
@@ -5,9 +5,9 @@ else
   ASSETS="[\"package.json\"]"
 fi
 if [ "$GITHUB_PRERELEASE" = "true" ]; then
-  GITHUB_PRERELEASE_PLUGIN="\"$GITHUB_PRERELEASE_PLUGIN_PATH\""
+  GITHUB_RELEASE_PLUGIN="\"$GITHUB_PRERELEASE_PLUGIN_PATH\""
 else
-  GITHUB_PRERELEASE_PLUGIN="\"@semantic-release/github\""
+  GITHUB_RELEASE_PLUGIN="\"@semantic-release/github\""
 fi
 cat >$FILE_PATH <<EOL
 {
@@ -21,7 +21,6 @@ cat >$FILE_PATH <<EOL
   ],
   "plugins": [
     "@semantic-release/commit-analyzer",
-    "@semantic-release/github",
     $GITHUB_RELEASE_PLUGIN,
     [
       "@semantic-release/npm",

--- a/semantic-release/create-config.sh
+++ b/semantic-release/create-config.sh
@@ -4,6 +4,11 @@ if [ "$IS_TRACKED" != "" ]; then
 else
   ASSETS="[\"package.json\"]"
 fi
+if [ "$GITHUB_PRERELEASE" = "true" ]; then
+  GITHUB_PRERELEASE_PLUGIN="\"$GITHUB_PRERELEASE_PLUGIN_PATH\""
+else
+  GITHUB_PRERELEASE_PLUGIN="\"@semantic-release/github\""
+fi
 cat >$FILE_PATH <<EOL
 {
   "branches": [
@@ -17,6 +22,7 @@ cat >$FILE_PATH <<EOL
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/github",
+    $GITHUB_RELEASE_PLUGIN,
     [
       "@semantic-release/npm",
       {

--- a/semantic-release/github-prerelease.js
+++ b/semantic-release/github-prerelease.js
@@ -1,0 +1,57 @@
+/**
+ * Creates a GitHub prerelease without changing semantic-release's normal
+ * branch/version semantics.
+ */
+export async function publish(_pluginConfig, context) {
+	const token = context.env.GITHUB_TOKEN;
+	const repository = context.env.GITHUB_REPOSITORY;
+	const apiUrl = context.env.GITHUB_API_URL || 'https://api.github.com';
+
+	if (!token) {
+		throw new Error('GITHUB_TOKEN is required to create a GitHub prerelease.');
+	}
+
+	if (!repository) {
+		throw new Error('GITHUB_REPOSITORY is required to create a GitHub prerelease.');
+	}
+
+	const [owner, repo] = repository.split('/');
+
+	if (!owner || !repo) {
+		throw new Error(`Invalid GITHUB_REPOSITORY value: ${repository}`);
+	}
+
+	const response = await fetch(`${apiUrl}/repos/${owner}/${repo}/releases`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/vnd.github+json',
+			Authorization: `Bearer ${token}`,
+			'Content-Type': 'application/json',
+			'X-GitHub-Api-Version': '2022-11-28',
+		},
+		body: JSON.stringify({
+			tag_name: context.nextRelease.gitTag,
+			target_commitish: context.nextRelease.gitHead,
+			name: context.nextRelease.name,
+			body: context.nextRelease.notes,
+			prerelease: true,
+			make_latest: 'false',
+		}),
+	});
+
+	if (!response.ok) {
+		throw new Error(
+			`Unable to create GitHub prerelease: ${response.status} ${await response.text()}`
+		);
+	}
+
+	const release = await response.json();
+
+	context.logger.log('Published GitHub prerelease: %s', release.html_url);
+
+	return {
+		name: 'GitHub prerelease',
+		url: release.html_url,
+		id: release.id,
+	};
+}


### PR DESCRIPTION
## Description
We are wanting to get rid of Brightspace/github-prerelease, however a number of our backend services rely on it for our deployment strategy. Allowing prereleases via the semantic-release action would enable us to use it without the extra configuration.

This PR is AI-assisted, so please let me know if anything doesn't make sense.