### PR TITLE
Updating update-package-lock readme to include D2L package registry

### DIFF
--- a/update-package-lock/README.md
+++ b/update-package-lock/README.md
@@ -41,7 +41,6 @@ Options:
 * `AUTO_MERGE_TOKEN`: Token to enable auto-merge on the PR. If no token is passed, the auto-merge will be skipped. See [setup details](#setting-up-auto-merge) below.
 * `AUTO_MERGE_METHOD`: (default: `merge`): Merge method to use when enabling auto-merge. Can be one of `merge`, `squash` or `rebase`.
 * `BRANCH_NAME` (default: `ghworkflow/package_lock_auto_update`): Name of the branch to add the changes to and open the pull request from.
-* `D2L_PACKAGE_REGISTRY_AUTH_TOKEN`: token used with accessing D2Ls NPM Proxy Registry
 * `NODE_AUTH_TOKEN`: Token for reading packages from already setup private registry. Do not use with `CODEARTIFACT_AUTH_TOKEN`, use [codeartifact-actions/npm/add-registry](https://github.com/Brightspace/codeartifact-actions/tree/master/npm) to setup the needed token before this action is run.
 * `COMMIT_MESSAGE` (default: `Auto Update Dependencies`): Commit message for the changes.
 * `DEFAULT_BRANCH` (default: `main`): Name of the default release branch for your repo.

--- a/update-package-lock/README.md
+++ b/update-package-lock/README.md
@@ -28,6 +28,8 @@ jobs:
       - uses: Brightspace/setup-node@main
         with:
           node-version-file: .nvmrc
+          cache: npm
+          d2l-registry-token: ${{ secrets.D2L_PACKAGE_REGISTRY_AUTH_TOKEN }}
       - name: Update package-lock.json
         uses: BrightspaceUI/actions/update-package-lock@main
         with:
@@ -39,6 +41,7 @@ Options:
 * `AUTO_MERGE_TOKEN`: Token to enable auto-merge on the PR. If no token is passed, the auto-merge will be skipped. See [setup details](#setting-up-auto-merge) below.
 * `AUTO_MERGE_METHOD`: (default: `merge`): Merge method to use when enabling auto-merge. Can be one of `merge`, `squash` or `rebase`.
 * `BRANCH_NAME` (default: `ghworkflow/package_lock_auto_update`): Name of the branch to add the changes to and open the pull request from.
+* `D2L_PACKAGE_REGISTRY_AUTH_TOKEN`: token used with accessing D2Ls NPM Proxy Registry
 * `NODE_AUTH_TOKEN`: Token for reading packages from already setup private registry. Do not use with `CODEARTIFACT_AUTH_TOKEN`, use [codeartifact-actions/npm/add-registry](https://github.com/Brightspace/codeartifact-actions/tree/master/npm) to setup the needed token before this action is run.
 * `COMMIT_MESSAGE` (default: `Auto Update Dependencies`): Commit message for the changes.
 * `DEFAULT_BRANCH` (default: `main`): Name of the default release branch for your repo.


### PR DESCRIPTION
Ticket: Required after changes done for https://desire2learn.atlassian.net/browse/HOD-4564

I was working on [KAIJU-977](https://desire2learn.atlassian.net/browse/KAIJU-977) and saw differences in samples and examples, so am just trying to standardize examples here in this README and in the Wiki page to better match the UCE sample given.

After a call-out today in the web-platform channel for a backport needing this tag, I figure it's important to get these samples up-to-date!

[KAIJU-977]: https://desire2learn.atlassian.net/browse/KAIJU-977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ